### PR TITLE
First phase of upload journey

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,3 +15,4 @@ class TestConfig(Config):
         "interval_step": 0.2,
         "interval_max": 0.5,
     }
+    os.environ["REDIS_URL"] = "redis@redis"

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,0 +1,16 @@
+from typing import Sequence
+
+
+def valid_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() == "csv"
+
+
+def mentors_and_mentees_present(filenames: list[str]) -> bool:
+    return set(map(lambda filename: filename.rsplit(".", 1)[0].lower(), filenames)) == {
+        "mentors",
+        "mentees",
+    }
+
+
+def valid_files(filenames: Sequence[str]) -> bool:
+    return mentors_and_mentees_present(filenames) and all(map(valid_file, filenames))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import csv
 import math
 from datetime import datetime
-
+from tempfile import tempdir
 import pytest as pytest
 
 from app import create_app
@@ -85,6 +85,7 @@ def test_data_path(tmpdir_factory):
 @pytest.fixture
 def client():
     app = create_app(TestConfig)
+    app.config["UPLOAD_FOLDER"] = tempdir
     with app.test_client() as client:
         yield client
 

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -1,0 +1,70 @@
+import io
+import pytest
+
+
+@pytest.mark.parametrize(
+    ["file_ending", "api_response"], (["csv", 202], ["doc", 415], ["csv.exe", 415])
+)
+def test_can_only_upload_csv(client, file_ending, api_response):
+    response = client.post(
+        "/upload",
+        data={
+            "files": [
+                (io.BytesIO(b"abcd"), f"mentors.{file_ending}"),
+                (io.BytesIO(b"abcd"), f"mentees.{file_ending}"),
+            ]
+        },
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == api_response
+
+
+@pytest.mark.parametrize(
+    ["files", "api_response"],
+    [
+        (
+            [
+                (io.BytesIO(b"abcd"), "mentors.csv"),
+                (io.BytesIO(b"abcd"), "mentees.csv"),
+            ],
+            202,
+        ),
+        ([(io.BytesIO(b"abcd"), "mentors.csv")], 415),
+        ([(io.BytesIO(b"abcd"), "mentees.csv")], 415),
+        (
+            [
+                (io.BytesIO(b"abcd"), "mentors.csv"),
+                (io.BytesIO(b"abcd"), "mentees.csv"),
+                (io.BytesIO(b"abcd"), "other.csv"),
+            ],
+            415,
+        ),
+    ],
+)
+def test_must_upload_two_files(client, files, api_response):
+    response = client.post(
+        "/upload", data={"files": files}, content_type="multipart/form-data"
+    )
+    assert response.status_code == api_response
+
+
+@pytest.mark.parametrize(
+    ["filenames", "api_response"],
+    (
+        (["mentors", "mentees"], 202),
+        (["mentors", "menteees"], 415),
+        (["MENTORS", "MENTEES"], 202),
+    ),
+)
+def test_filenames_are_mentors_and_mentees(client, filenames, api_response):
+    response = client.post(
+        "/upload",
+        data={
+            "files": [
+                (io.BytesIO(b"abcd"), f"{filenames[0]}.csv"),
+                (io.BytesIO(b"abcd"), f"{filenames[1]}.csv"),
+            ]
+        },
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == api_response


### PR DESCRIPTION
This changes the "/upload" route and does the following:
- checks if there are exactly two files, and returns an error message if not
- checks that the two files are called "mentors.csv" and "mentees.csv" and returns an error if not
- checks that the two files actually end in ".csv" to reduce security risk, and returns an error if not

Currently it does nothing at all with these files, but it's enough to start building out the frontend