### PR TITLE
Fixup deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,8 @@ jobs:
   heroku-push-and-release:
     runs-on: ubuntu-20.04
     env:
-      HEROKU_API_KEY: ${{ github.secrets.HEROKU_API_KEY }}
-      HEROKU_EMAIL: ${{ github.secrets.HEROKU_EMAIL }}
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
     steps:
       - name: Push images to Heroku
         run: |


### PR DESCRIPTION
the secrets context in GitHub actions is accessed just as 'secrets', not 'github.secrets'!