### PR TITLE
Save uploaded file and put folder into session

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,3 +1,7 @@
+import string
+import random
+
+
 def valid_file(filename: str) -> bool:
     return "." in filename and filename.rsplit(".", 1)[1].lower() == "csv"
 
@@ -19,3 +23,7 @@ def mentors_and_mentees_present(filenames: list[str]) -> bool:
 
 def valid_files(filenames: list[str]) -> bool:
     return mentors_and_mentees_present(filenames) and all(map(valid_file, filenames))
+
+
+def random_string():
+    return "".join(random.choice(string.ascii_lowercase) for _ in range(10))

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -9,6 +9,7 @@ from flask import (
     url_for,
     send_from_directory,
     after_this_request,
+    session,
 )
 import pathlib
 import shutil
@@ -47,6 +48,7 @@ def upload():
                 file.save(
                     os.path.join(current_app.config["UPLOAD_FOLDER"], folder, filename)
                 )
+                session["data-folder"] = folder
             return jsonify(task_id="1"), 202
         else:
             if len(files) != 2:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -13,9 +13,11 @@ from flask import (
 import pathlib
 import shutil
 
+from werkzeug.utils import secure_filename
+
 from app.extensions import celery
 from app.main import main_bp
-from app.helpers import valid_files
+from app.helpers import valid_files, random_string
 from app.tasks.tasks import async_process_data
 from matching.factory import ParticipantFactory
 from matching.mentee import Mentee
@@ -36,6 +38,15 @@ def upload():
         files = request.files.getlist("files")
         filenames = [file.filename for file in files]
         if len(files) == 2 and valid_files(filenames):
+            folder = random_string()
+            for file in files:
+                pathlib.Path(current_app.config["UPLOAD_FOLDER"], folder).mkdir(
+                    parents=True, exist_ok=True
+                )
+                filename = secure_filename(file.filename)
+                file.save(
+                    os.path.join(current_app.config["UPLOAD_FOLDER"], folder, filename)
+                )
             return jsonify(task_id="1"), 202
         else:
             if len(files) != 2:
@@ -44,6 +55,8 @@ def upload():
                 )
             elif not valid_files(filenames):
                 error_message = "Filenames incorrect. Please label your files as 'mentees.csv and mentors.csv"
+            else:
+                error_message = "Unspecified error. Please contact the admin team"
             return make_response(
                 render_template("input.html", error_message=error_message), 415
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pathlib
 from datetime import datetime
 import pytest as pytest
 
+import app.helpers
 from app import create_app
 from app.config import TestConfig
 from matching.mentee import Mentee
@@ -85,9 +86,9 @@ def test_data_path(tmpdir_factory):
 
 @pytest.fixture
 def client(test_data_path):
-    app = create_app(TestConfig)
-    app.config["UPLOAD_FOLDER"] = test_data_path
-    with app.test_client() as client:
+    test_app = create_app(TestConfig)
+    test_app.config["UPLOAD_FOLDER"] = test_data_path
+    with test_app.test_client() as client:
         yield client
 
 
@@ -98,3 +99,11 @@ def test_participants(test_data_path, known_file):
     create_participant_list_from_path(Mentee, test_data_path)
     create_participant_list_from_path(Mentor, test_data_path)
     yield
+
+
+@pytest.fixture(autouse=True)
+def predictable_random_string(monkeypatch):
+    def predictable_string():
+        return "abcdef"
+
+    monkeypatch.setattr(app.helpers, "random_string", predictable_string)

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -1,7 +1,7 @@
 import io
 import pathlib
 import pytest
-from flask import current_app
+from flask import current_app, session
 
 
 class TestUpload:
@@ -91,3 +91,16 @@ class TestUpload:
         assert pathlib.Path(
             current_app.config["UPLOAD_FOLDER"], "abcdef", "mentors.csv"
         ).exists()
+
+    def test_session_has_folder_name(self, client):
+        client.post(
+            "/upload",
+            data={
+                "files": [
+                    (io.BytesIO(b"abcd"), "mentors.csv"),
+                    (io.BytesIO(b"abcd"), "mentees.csv"),
+                ]
+            },
+            content_type="multipart/form-data",
+        )
+        assert session["data-folder"] == "abcdef"

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -1,77 +1,93 @@
 import io
+import pathlib
 import pytest
+from flask import current_app
 
 
-@pytest.mark.parametrize(
-    ["file_ending", "api_response"], (["csv", 202], ["doc", 415], ["csv.exe", 415])
-)
-def test_can_only_upload_csv(client, file_ending, api_response):
-    response = client.post(
-        "/upload",
-        data={
-            "files": [
-                (io.BytesIO(b"abcd"), f"mentors.{file_ending}"),
-                (io.BytesIO(b"abcd"), f"mentees.{file_ending}"),
-            ]
-        },
-        content_type="multipart/form-data",
+class TestUpload:
+    @pytest.mark.parametrize(
+        ["file_ending", "api_response"], (["csv", 202], ["doc", 415], ["csv.exe", 415])
     )
-    assert response.status_code == api_response
+    def test_can_only_upload_csv(self, client, file_ending, api_response):
+        response = client.post(
+            "/upload",
+            data={
+                "files": [
+                    (io.BytesIO(b"abcd"), f"mentors.{file_ending}"),
+                    (io.BytesIO(b"abcd"), f"mentees.{file_ending}"),
+                ]
+            },
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == api_response
 
-
-@pytest.mark.parametrize(
-    ["files", "api_response"],
-    [
-        (
-            [
-                (io.BytesIO(b"abcd"), "mentors.csv"),
-                (io.BytesIO(b"abcd"), "mentees.csv"),
-            ],
-            202,
-        ),
-        ([(io.BytesIO(b"abcd"), "mentors.csv")], 415),
-        ([(io.BytesIO(b"abcd"), "mentees.csv")], 415),
-        (
-            [
-                (io.BytesIO(b"abcd"), "mentors.csv"),
-                (io.BytesIO(b"abcd"), "mentees.csv"),
-                (io.BytesIO(b"abcd"), "other.csv"),
-            ],
-            415,
-        ),
-        (
-            [
-                (io.BytesIO(b"abcd"), "unkown/random/path/mentors.csv"),
-                (io.BytesIO(b"abcd"), "unkown/random/path/mentees.csv"),
-            ],
-            202,
-        ),
-    ],
-)
-def test_must_upload_two_files(client, files, api_response):
-    response = client.post(
-        "/upload", data={"files": files}, content_type="multipart/form-data"
+    @pytest.mark.parametrize(
+        ["files", "api_response"],
+        [
+            (
+                [
+                    (io.BytesIO(b"abcd"), "mentors.csv"),
+                    (io.BytesIO(b"abcd"), "mentees.csv"),
+                ],
+                202,
+            ),
+            ([(io.BytesIO(b"abcd"), "mentors.csv")], 415),
+            ([(io.BytesIO(b"abcd"), "mentees.csv")], 415),
+            (
+                [
+                    (io.BytesIO(b"abcd"), "mentors.csv"),
+                    (io.BytesIO(b"abcd"), "mentees.csv"),
+                    (io.BytesIO(b"abcd"), "other.csv"),
+                ],
+                415,
+            ),
+            (
+                [
+                    (io.BytesIO(b"abcd"), "unkown/random/path/mentors.csv"),
+                    (io.BytesIO(b"abcd"), "unkown/random/path/mentees.csv"),
+                ],
+                202,
+            ),
+        ],
     )
-    assert response.status_code == api_response
+    def test_must_upload_two_files(self, client, files, api_response):
+        response = client.post(
+            "/upload", data={"files": files}, content_type="multipart/form-data"
+        )
+        assert response.status_code == api_response
 
-
-@pytest.mark.parametrize(
-    ["filenames", "api_response"],
-    (
-        (["mentors", "mentees"], 202),
-        (["mentors", "menteees"], 415),
-        (["MENTORS", "MENTEES"], 202),
-    ),
-)
-def test_filenames_are_mentors_and_mentees(client, filenames, api_response):
-    response = client.post(
-        "/upload",
-        data={
-            "files": [
-                (io.BytesIO(b"abcd"), f"{filenames[0]}.csv"),
-                (io.BytesIO(b"abcd"), f"{filenames[1]}.csv"),
-            ]
-        },
-        content_type="multipart/form-data",
+    @pytest.mark.parametrize(
+        ["filenames", "api_response"],
+        (
+            (["mentors", "mentees"], 202),
+            (["mentors", "menteees"], 415),
+            (["MENTORS", "MENTEES"], 202),
+        ),
     )
-    assert response.status_code == api_response
+    def test_filenames_are_mentors_and_mentees(self, client, filenames, api_response):
+        response = client.post(
+            "/upload",
+            data={
+                "files": [
+                    (io.BytesIO(b"abcd"), f"{filenames[0]}.csv"),
+                    (io.BytesIO(b"abcd"), f"{filenames[1]}.csv"),
+                ]
+            },
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == api_response
+
+    def test_upload_saves_file(self, client, test_data_path):
+        client.post(
+            "/upload",
+            data={
+                "files": [
+                    (io.BytesIO(b"abcd"), "mentors.csv"),
+                    (io.BytesIO(b"abcd"), "mentees.csv"),
+                ]
+            },
+            content_type="multipart/form-data",
+        )
+        assert pathlib.Path(
+            current_app.config["UPLOAD_FOLDER"], "abcdef", "mentors.csv"
+        ).exists()


### PR DESCRIPTION
When a user has uploaded their files they're saved to a random location ready for the user to commit to processing. The saved location is passed back to the user as a key in the session cookie, so it can be captured on the next page when we come to process the files.

Wider question here of whether users expect distinct "upload" and "start processing" steps, or expect both steps in one action. @johnpeart I'm going to keep the upload --> start processing journey for now, but maybe one to keep in mind for future