### PR TITLE
Add upload form

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -57,8 +57,8 @@ def upload():
                 )
             elif not valid_files(filenames):
                 error_message = (
-                    "Filenames incorrect. Please label your files as 'mentees.csv and"
-                    " mentors.csv"
+                    "Filenames incorrect. Please label your files as 'mentees.csv' and"
+                    " 'mentors.csv'"
                 )
             else:
                 error_message = "Unspecified error. Please contact the admin team"

--- a/app/templates/input.html
+++ b/app/templates/input.html
@@ -1,11 +1,20 @@
 {% extends "base.html" %}
 {% block title %}Upload{% endblock %}
 {% block head %}
-    {{ super() }}
+{{ super() }}
 {% endblock %}
 {% block content %}
-    <h1>Upload</h1>
-    <p>
-      There should be a button here
-    </p>
+<h1>Upload</h1>
+{% if error_message %}
+<p class=error><strong>Error:</strong> {{ error_message }}
+  {% endif %}
+<form method=post enctype=multipart/form-data action="{{ url_for('main.upload') }}">
+  <label class="label" for="file-upload-1">
+    Upload your files
+  </label>
+  <input type=file name=files multiple="" id="file-upload-1">
+  <br>
+  <br>
+  <input type="submit" class="button" value="upload">
+</form>
 {% endblock %}

--- a/app/templates/input.html
+++ b/app/templates/input.html
@@ -4,17 +4,19 @@
 {{ super() }}
 {% endblock %}
 {% block content %}
-<h1>Upload</h1>
+<h1 class="heading-lg">Upload</h1>
 {% if error_message %}
-<p class=error><strong>Error:</strong> {{ error_message }}
-  {% endif %}
-<form method=post enctype=multipart/form-data action="{{ url_for('main.upload') }}">
-  <label class="label" for="file-upload-1">
-    Upload your files
-  </label>
-  <input type=file name=files multiple="" id="file-upload-1">
-  <br>
-  <br>
-  <input type="submit" class="button" value="upload">
-</form>
+  <blockquote class="error warning-text">
+    <strong>Error:</strong> {{ error_message }}
+  </blockquote>
+{% endif %}
+  <form method=post enctype=multipart/form-data action="{{ url_for('main.upload') }}">
+    <div class="form-group" style="padding-bottom: 20px;">
+      <label class="label label-md" for="files">
+        Select your files
+      </label>
+      <input type="file" name="files" multiple="" id="files">
+    </div>
+    <input type="submit" class="button button--action" value="Upload">
+  </form>
 {% endblock %}


### PR DESCRIPTION
This change will create the upload form, which will enable users to upload their participants ready to be matched.

As of 2022-02-10 it is pretty ugly:

![Screenshot 2022-02-10 at 10 53 32](https://user-images.githubusercontent.com/3410350/153392454-19b63193-198f-405e-8dd1-b1844532df24.png)

And the error messages could be clearer:

![Screenshot 2022-02-10 at 10 54 09](https://user-images.githubusercontent.com/3410350/153392561-7ad5ff08-409f-473a-8978-f004a0b02a65.png)

However, it's a start.
