### PR TITLE
Add 'process' user journey

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -99,8 +99,10 @@ def process():
 @main_bp.route("/tasks", methods=["POST"])
 def run_task():
     current_app.logger.debug(request.get_json())
-    task_id = request.get_json()["task_id"]
-    folder = pathlib.Path(os.path.join(current_app.config["UPLOAD_FOLDER"], task_id))
+    data_folder = request.get_json()["data_folder"]
+    folder = pathlib.Path(
+        os.path.join(current_app.config["UPLOAD_FOLDER"], data_folder)
+    )
     mentors = [
         mentor.to_dict()
         for mentor in create_participant_list_from_path(Mentor, path_to_data=folder)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -14,7 +14,7 @@ from flask import (
 import pathlib
 import shutil
 
-from werkzeug.utils import secure_filename
+from werkzeug.utils import secure_filename, redirect
 
 from app.extensions import celery
 from app.main import main_bp
@@ -49,7 +49,7 @@ def upload():
                     os.path.join(current_app.config["UPLOAD_FOLDER"], folder, filename)
                 )
                 session["data-folder"] = folder
-            return jsonify(task_id="1"), 202
+            return redirect(url_for("main.process", folder_name=folder))
         else:
             if len(files) != 2:
                 error_message = (
@@ -86,6 +86,11 @@ def download(task_id):
         directory=pathlib.Path(current_app.config["UPLOAD_FOLDER"]),
         path=f"{task_id}.zip",
     )
+
+
+@main_bp.route("/process/<folder_name>", methods=["GET", "POST"])
+def process(folder_name):
+    return make_response("Hello world", 200)
 
 
 @main_bp.route("/tasks", methods=["POST"])

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -88,9 +88,12 @@ def download(task_id):
     )
 
 
-@main_bp.route("/process/<folder_name>", methods=["GET", "POST"])
-def process(folder_name):
-    return make_response("Hello world", 200)
+@main_bp.route("/process", methods=["GET"])
+def process():
+    if not session.get("data-folder"):
+        return redirect(url_for("main.upload"))
+    else:
+        return render_template("process.html")
 
 
 @main_bp.route("/tasks", methods=["POST"])

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,10 +1,10 @@
-function handleClick(task_id) {
+function handleClick(data_folder) {
   fetch('/tasks', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ task_id: task_id }),
+    body: JSON.stringify({ data_folder: data_folder }),
   })
   .then(response => response.json())
   .then(data => getStatus(data.task_id));

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -18,4 +18,22 @@
         </button>
     </div>
 </div>
+
+<dialog class="dialog" id="dialog-box">
+	<!-- this dialog will only show when required -->
+	<!-- note that this won't work in Safari yet -->
+	<section class="dialog--header">
+		<h2 class="heading-lg dialog--title">Matching complete</h2>
+	</section>
+	<section class="dialog--content">
+		<p>The matching process is complete.</p>
+		<p>Use the <kbd>Download matches</kbd> button to get the results.</p>
+	</section>
+	<footer class="dialog--actions">
+		<a class="button button--dialog" id="download-matches" title="Download matching results">Download
+			matches</a>
+		<button onclick="closeDialog('dialog-box')" class="button button--secondary button--dialog button--close">Close
+			this dialog</button>
+	</footer>
+</dialog>
 {% endblock %}

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}Process matches{% endblock %}
+{% block head %}{{ super() }}{% endblock %}
+{%  block content %}
+<div class="grid-row">
+    <header class="page--header">
+        <div class="grid-column-full">
+            <h1 class="page--heading">
+                Process data
+            </h1>
+        </div>
+    </header>
+</div>
+<div class="grid-row main-wrapper--lg">
+    <div class="grid-column-full">
+        <button class="button" type="button" onclick="handleClick({{ session['data-folder'] }})">
+            Process your data
+        </button>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -78,9 +78,9 @@ class TestIntegration:
     ):
         known_file(pathlib.Path(test_data_path, test_task), "mentee", output)
         known_file(pathlib.Path(test_data_path, test_task), "mentor", output)
-        processing_id = client.post("/tasks", json={"task_id": test_task}).get_json()[
-            "task_id"
-        ]
+        processing_id = client.post(
+            "/tasks", json={"data_folder": test_task}
+        ).get_json()["task_id"]
 
         resp = client.get(f"/tasks/{processing_id}")
         content = resp.get_json()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,10 @@
 import os.path
 import pathlib
 import time
+from unittest.mock import patch
 
 import pytest
-from flask import current_app
+from flask import current_app, session
 from matching.mentee import Mentee
 from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path
@@ -29,6 +30,8 @@ class TestIntegration:
             test_data_path / "mentors.csv",
         )
         files = []
+        patched_random = patch("app.main.routes.random_string", return_value="abcdef")
+        patched_random.start()
         try:
             files = [open(fpath, "rb") for fpath in src_file_paths]
             resp = client.post(
@@ -36,15 +39,15 @@ class TestIntegration:
                 data={
                     "files": files,
                 },
+                follow_redirects=True,
             )
         finally:
             for fp in files:
                 fp.close()
-
-        content = resp.get_json()
-        task_id = content["task_id"]
-        assert resp.status_code == 202
-        assert task_id == "1"
+        patched_random.stop()
+        data_folder = session["data-folder"]
+        assert resp.status_code == 200
+        assert data_folder == "abcdef"
 
     def test_process_data(self, celery_app, celery_worker, known_file, test_data_path):
         known_file(test_data_path, "mentee", 50)

--- a/tests/test_process_route.py
+++ b/tests/test_process_route.py
@@ -1,0 +1,7 @@
+from flask import url_for
+
+
+def test_no_data_folder_in_session_redirects_to_input(client):
+    response = client.get("/process", follow_redirects=True)
+    assert response.request.path != url_for("main.process")
+    assert response.request.path == url_for("main.upload")

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -122,4 +122,4 @@ class TestUpload:
             content_type="multipart/form-data",
             follow_redirects=True,
         )
-        assert response.request.path == url_for("main.process", folder_name="abcdef")
+        assert response.request.path == url_for("main.process")

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -1,12 +1,12 @@
 import io
 import pathlib
 import pytest
-from flask import current_app, session
+from flask import current_app, session, url_for
 
 
 class TestUpload:
     @pytest.mark.parametrize(
-        ["file_ending", "api_response"], (["csv", 202], ["doc", 415], ["csv.exe", 415])
+        ["file_ending", "api_response"], (["csv", 200], ["doc", 415], ["csv.exe", 415])
     )
     def test_can_only_upload_csv(self, client, file_ending, api_response):
         response = client.post(
@@ -18,6 +18,7 @@ class TestUpload:
                 ]
             },
             content_type="multipart/form-data",
+            follow_redirects=True,
         )
         assert response.status_code == api_response
 
@@ -29,7 +30,7 @@ class TestUpload:
                     (io.BytesIO(b"abcd"), "mentors.csv"),
                     (io.BytesIO(b"abcd"), "mentees.csv"),
                 ],
-                202,
+                200,
             ),
             ([(io.BytesIO(b"abcd"), "mentors.csv")], 415),
             ([(io.BytesIO(b"abcd"), "mentees.csv")], 415),
@@ -46,22 +47,25 @@ class TestUpload:
                     (io.BytesIO(b"abcd"), "unkown/random/path/mentors.csv"),
                     (io.BytesIO(b"abcd"), "unkown/random/path/mentees.csv"),
                 ],
-                202,
+                200,
             ),
         ],
     )
     def test_must_upload_two_files(self, client, files, api_response):
         response = client.post(
-            "/upload", data={"files": files}, content_type="multipart/form-data"
+            "/upload",
+            data={"files": files},
+            content_type="multipart/form-data",
+            follow_redirects=True,
         )
         assert response.status_code == api_response
 
     @pytest.mark.parametrize(
         ["filenames", "api_response"],
         (
-            (["mentors", "mentees"], 202),
+            (["mentors", "mentees"], 200),
             (["mentors", "menteees"], 415),
-            (["MENTORS", "MENTEES"], 202),
+            (["MENTORS", "MENTEES"], 200),
         ),
     )
     def test_filenames_are_mentors_and_mentees(self, client, filenames, api_response):
@@ -74,6 +78,7 @@ class TestUpload:
                 ]
             },
             content_type="multipart/form-data",
+            follow_redirects=True,
         )
         assert response.status_code == api_response
 
@@ -104,3 +109,17 @@ class TestUpload:
             content_type="multipart/form-data",
         )
         assert session["data-folder"] == "abcdef"
+
+    def test_valid_upload_redirects_to_process_page(self, client):
+        response = client.post(
+            "/upload",
+            data={
+                "files": [
+                    (io.BytesIO(b"abcd"), "mentors.csv"),
+                    (io.BytesIO(b"abcd"), "mentees.csv"),
+                ]
+            },
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+        assert response.request.path == url_for("main.process", folder_name="abcdef")


### PR DESCRIPTION
This change alters some underlying connections by renaming variables so that they're clearer. It also adds the 'process' section of the user journey. Some of that is replicated from the index, which will be decommissioned before long.

Actually checking if the journey works end-to-end will need me to dip into pytest-bdd to manage the user interactions - clicking next, uploading files, etc etc. 