### PR TITLE
Change CSS file

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     {% block head %}
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="https://www.civilservice.lgbt/assets/styles/styles.css">
     <title>Mentor matcher • {% block title %}{% endblock %}</title>
     {% endblock %}
 </head>


### PR DESCRIPTION
The CSS file is a copy of the file that is on the [www.civilservice.lgbt](http://www.civilservice.lgbt/) website. That, in turn, is refreshed from a GitHub repo called ‘Magenta’ each night when the site rebuilds. 

This change directly links to the main site CSS file, rather than maintaining a separate one, so the files stay in lockstep.

This means updates to the Magenta theme are automatically reflected on this site.