### PR TITLE
Add start page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -29,6 +29,11 @@ from matching.process import create_participant_list_from_path, create_mailing_l
 @main_bp.route("/", methods=["GET"])
 def index():
     return render_template("index.html", title="Mentor matcher")
+    
+
+@main_bp.route("/match", methods=["GET"])
+def match():
+    return render_template("match.html", title="Mentor matcher")
 
 
 @main_bp.route("/cookies")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -28,7 +28,11 @@ from matching.process import create_participant_list_from_path, create_mailing_l
 
 @main_bp.route("/", methods=["GET"])
 def index():
-    return render_template("index.html", title="Hello World!")
+    return render_template("index.html", title="Mentor matcher")
+
+@main_bp.route("/cookies")
+def cookies():
+    return render_template("cookies.html", title="Cookies")
 
 
 @main_bp.route("/upload", methods=["GET", "POST"])

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -29,7 +29,7 @@ from matching.process import create_participant_list_from_path, create_mailing_l
 @main_bp.route("/", methods=["GET"])
 def index():
     return render_template("index.html", title="Mentor matcher")
-    
+ 
 
 @main_bp.route("/match", methods=["GET"])
 def match():

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -30,9 +30,11 @@ from matching.process import create_participant_list_from_path, create_mailing_l
 def index():
     return render_template("index.html", title="Mentor matcher")
 
+
 @main_bp.route("/cookies")
 def cookies():
     return render_template("cookies.html", title="Cookies")
+
 
 @main_bp.route("/privacy-and-data")
 def privacy():

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -35,7 +35,7 @@ def cookies():
     return render_template("cookies.html", title="Cookies")
 
 @main_bp.route("/privacy-and-data")
-def cookies():
+def privacy():
     return render_template("privacy-and-data.html", title="Privacy and data")
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -34,6 +34,10 @@ def index():
 def cookies():
     return render_template("cookies.html", title="Cookies")
 
+@main_bp.route("/privacy-and-data")
+def cookies():
+    return render_template("privacy-and-data.html", title="Privacy and data")
+
 
 @main_bp.route("/upload", methods=["GET", "POST"])
 def upload():

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -28,7 +28,15 @@ from matching.process import create_participant_list_from_path, create_mailing_l
 
 @main_bp.route("/", methods=["GET"])
 def index():
-    return render_template("index.html", title="Hello World!")
+    return render_template("index.html", title="Mentor matcher")
+
+@main_bp.route("/cookies")
+def cookies():
+    return render_template("cookies.html", title="Cookies")
+
+@main_bp.route("/privacy-and-data")
+def privacy():
+    return render_template("privacy-and-data.html", title="Privacy and data")
 
 
 @main_bp.route("/upload", methods=["GET", "POST"])

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -67,7 +67,7 @@
             </li>
 						<li class="footer--list-item">
 							<a class="footer--link" href="/cookies" title="Read the cookies policy">
-								Cookies
+								Privacy, data and cookies
 							</a>
 						</li>
 					</ul>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -66,7 +66,7 @@
 							</a>
             </li>
 						<li class="footer--list-item">
-							<a class="footer--link" href="/privacy-and-data" title="Read the cookies policy">
+							<a class="footer--link" href="/privacy-and-data" title="Read the privacy and data policy">
 								Privacy and data
 							</a>
 						</li>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -66,8 +66,13 @@
 							</a>
             </li>
 						<li class="footer--list-item">
+							<a class="footer--link" href="/privacy-and-data" title="Read the cookies policy">
+								Privacy and data
+							</a>
+						</li>
+						<li class="footer--list-item">
 							<a class="footer--link" href="/cookies" title="Read the cookies policy">
-								Privacy, data and cookies
+								Cookies
 							</a>
 						</li>
 					</ul>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -22,12 +22,14 @@
     <div class="breadcrumbs breadcrumbs--collapse-on-mobile">
 	    <ol class="breadcrumbs--list">
 		    
+        {% block breadcrumbs %}
 		    <li class="breadcrumbs--list-item">
 			    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt">Home</a>
 		    </li>
 		    <li class="breadcrumbs--list-item">
 			    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt/tools">Tools</a>
 		    </li>
+        {% endblock %}
 		    
 	    </ol>
     </div>
@@ -62,6 +64,8 @@
 							<a class="footer--link" href="https://www.civilservice.lgbt/mentoring" title="Find out more about our mentoring programme">
 								Our mentoring programme
 							</a>
+            </li>
+						<li class="footer--list-item">
 							<a class="footer--link" href="/cookies" title="Read the cookies policy">
 								Cookies
 							</a>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -32,8 +32,23 @@
     </div>
 		<main class="main-wrapper main-wrapper--auto-spacing" id="main-content" role="main">
 
-			<div id="content">{% block content %}{% endblock %}</div>
+      <article class="article--page">
+      
+        <div class="grid-row">
+	        <header class="page--header">
+		        <div class="grid-column-full">
+			        <span class="page--caption">{% block pagecaption %}Tools{% endblock %}</span>
+			        <h1 class="page--heading">{% block pageheading %}Mentor matcher{% endblock %}</h1>
+		        </div>
+		        <div class="grid-column-two-thirds">
+			        <p class="page--excerpt">{% block pageexcerpt %}This tool helps you to match mentors to mentees as part of the Civil Service LGBT+ mentoring programme.{% endblock %}</p>
+		        </div>
+	        </header>
+        </div>
+  
+			  <div id="content">{% block content %}{% endblock %}</div>
 
+      </article>
 		</main>
 	</div>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,16 +21,13 @@
 	<div class="width-container">
     <div class="breadcrumbs breadcrumbs--collapse-on-mobile">
 	    <ol class="breadcrumbs--list">
-		    
-        {% block breadcrumbs %}
 		    <li class="breadcrumbs--list-item">
 			    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt">Home</a>
 		    </li>
 		    <li class="breadcrumbs--list-item">
 			    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt/tools">Tools</a>
 		    </li>
-        {% endblock %}
-		    
+		    {% block breadcrumbs %}{% endblock %}
 	    </ol>
     </div>
 		<main class="main-wrapper main-wrapper--auto-spacing" id="main-content" role="main">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -62,6 +62,9 @@
 							<a class="footer--link" href="https://www.civilservice.lgbt/mentoring" title="Find out more about our mentoring programme">
 								Our mentoring programme
 							</a>
+							<a class="footer--link" href="/cookies" title="Read the cookies policy">
+								Cookies
+							</a>
 						</li>
 					</ul>
 				</div>

--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -10,34 +10,16 @@
   </li>
 {% endblock %}
 
+{% block pagecaption %}Mentor matcher{% endblock %}
+{% block pageheading %}Cookies{% endblock %}
+{% block pageexcerpt %}This page explains the use of cookies on this website.{% endblock %}
+
 {% block content %}
-
-<article class="article--news">
-
-	<div class="grid-row">
-	  <header class="page--header">
-		  <div class="grid-column-full">
-			  <span class="page--caption">Mentor matcher</span>
-			  <h1 class="page--heading">Cookies</h1>
-		  </div>
-		  <div class="grid-column-two-thirds">
-			  <p class="page--excerpt">This page explains the use of cookies on this website.</p>
-		  </div>
-	  </header>
-  </div>
-
 	<div class="grid-row">
 		<div class="grid-column-two-thirds">
-
 			<div class="page--content">
-
 				<p><i>Content here</i></p>
-        
 			</div>
-
 		</div>
 	</div>
-
-</article>
-
 {% endblock %}

--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Match mentees to mentors{% endblock %}
+{% block head %}
+{{ super() }}
+{% endblock %}
+
+{% block breadcrumbs %}
+  <li class="breadcrumbs--list-item">
+    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt">Home</a>
+  </li>
+  <li class="breadcrumbs--list-item">
+    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt/tools">Tools</a>
+  </li>
+  <li class="breadcrumbs--list-item">
+    <a class="breadcrumbs--link" href="/">Mentor matcher</a>
+  </li>
+{% endblock %}
+
+{% block content %}
+
+<article class="article--news">
+
+	<div class="grid-row">
+	  <header class="page--header">
+		  <div class="grid-column-full">
+			  <span class="page--caption">Mentor matcher</span>
+			  <h1 class="page--heading">Privacy and data</h1>
+		  </div>
+		  <div class="grid-column-two-thirds">
+			  <p class="page--excerpt">This page explains the data processing and cookies use for this website.</p>
+		  </div>
+	  </header>
+  </div>
+
+	<div class="grid-row">
+		<div class="grid-column-two-thirds">
+
+			<div class="page--content">
+
+				<p><i>Content here</i></p>
+        
+			</div>
+
+		</div>
+	</div>
+
+</article>
+
+{% endblock %}

--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -6,12 +6,6 @@
 
 {% block breadcrumbs %}
   <li class="breadcrumbs--list-item">
-    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt">Home</a>
-  </li>
-  <li class="breadcrumbs--list-item">
-    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt/tools">Tools</a>
-  </li>
-  <li class="breadcrumbs--list-item">
     <a class="breadcrumbs--link" href="/">Mentor matcher</a>
   </li>
 {% endblock %}

--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -24,7 +24,7 @@
 	  <header class="page--header">
 		  <div class="grid-column-full">
 			  <span class="page--caption">Mentor matcher</span>
-			  <h1 class="page--heading">Privacy and data</h1>
+			  <h1 class="page--heading">Cookies</h1>
 		  </div>
 		  <div class="grid-column-two-thirds">
 			  <p class="page--excerpt">This page explains the use of cookies on this website.</p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,19 +5,6 @@
 {% endblock %}
 {% block content %}
 
-<div class="grid-row">
-	<header class="page--header">
-		<div class="grid-column-full">
-			<span class="page--caption">Tools</span>
-			<h1 class="page--heading">Mentor matcher</h1>
-		</div>
-		<div class="grid-column-two-thirds">
-			<p class="page--excerpt">This tool helps you to match mentors to mentees as part of the Civil Service LGBT+
-				mentoring programme.</p>
-		</div>
-	</header>
-</div>
-
 <div class="grid-row main-wrapper--lg">
 	<div class="grid-column-full">
 		<h2>Tasks</h2>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,54 +5,21 @@
 {% endblock %}
 {% block content %}
 
-<div class="grid-row main-wrapper--lg">
-	<div class="grid-column-full">
-		<h2>Tasks</h2>
-		<div class="page--content">
-			<p>Pick a task length.</p>
-			<div class="button-group" role="group" aria-label="Basic example">
-				<button type="button" class="button" onclick="handleClick('small')">50 participants</button>
-				<button type="button" class="button" onclick="handleClick('large')">500 participants</button>
-			</div>
-		</div>
-	</div>
+<div class="grid-row">
+  <div class="grid-column-two-thirds">
+    <div class="page--content">
+    <h2 class="heading-md">Before you start</h2>
+    <ol>
+      <li><strong>This tool will only work with data in specific formats.</strong> You must have two files – <code>mentees.csv</code> and <code>mentors.csv</code> – to start the matching process. Those files need to be formatted with specific column headings. You can <a href="#">download a template</a> from this website.</li>
+      <li><strong>Do not close your browser window during the matching process.</strong> Doing this may cause the matching process to fail and you to lose your matches.</li>
+      <li><strong>The larger the number of matches you need, the longer this takes.</strong> Matching mentors to mentees takes around 10 minutes to match 500 participants.</li>
+    </ol>
+    <hr>
+    <div class="button-group">
+      <a href="/match" class="button button--action">Start now</a>
+    </div>
+    </div>
+  </div>
 </div>
 
-<dialog class="dialog" id="dialog-box">
-	<!-- this dialog will only show when required -->
-	<!-- note that this won't work in Safari yet -->
-	<section class="dialog--header">
-		<h2 class="heading-lg dialog--title">Matching complete</h2>
-	</section>
-	<section class="dialog--content">
-		<p>The matching process is complete.</p>
-		<p>Use the <kbd>Download matches</kbd> button to get the results.</p>
-	</section>
-	<footer class="dialog--actions">
-		<a class="button button--dialog" id="download-matches" title="Download matching results">Download
-			matches</a>
-		<button onclick="closeDialog('dialog-box')" class="button button--secondary button--dialog button--close">Close
-			this dialog</button>
-	</footer>
-</dialog>
-
-<div class="grid-row main-wrapper--lg">
-	<div class="grid-column-full">
-		<details>
-			<summary>Logging information</summary>
-			<table class="table">
-				<thead>
-					<tr>
-						<th width="50%">ID</th>
-						<th width="20%">Status</th>
-						<th width="30%">Result</th>
-					</tr>
-				</thead>
-				<tbody id="tasks">
-
-				</tbody>
-			</table>
-		</details>
-	</div>
-</div>
 {% endblock %}

--- a/app/templates/match.html
+++ b/app/templates/match.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}Match mentees to mentors{% endblock %}
+{% block head %}
+{{ super() }}
+{% endblock %}
+
+{% block pagecaption %}Mentor matcher{% endblock %}
+{% block pageheading %}Match mentors to mentees{% endblock %}
+{% block pageexcerpt %}Upload your data and wait for matching to complete.{% endblock %}
+
+{% block content %}
+
+<div class="grid-row main-wrapper--lg">
+	<div class="grid-column-full">
+		<h2>Tasks</h2>
+		<div class="page--content">
+			<p>Pick a task length.</p>
+			<div class="button-group" role="group" aria-label="Basic example">
+				<button type="button" class="button" onclick="handleClick('small')">50 participants</button>
+				<button type="button" class="button" onclick="handleClick('large')">500 participants</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<dialog class="dialog" id="dialog-box">
+	<!-- this dialog will only show when required -->
+	<!-- note that this won't work in Safari yet -->
+	<section class="dialog--header">
+		<h2 class="heading-lg dialog--title">Matching complete</h2>
+	</section>
+	<section class="dialog--content">
+		<p>The matching process is complete.</p>
+		<p>Use the <kbd>Download matches</kbd> button to get the results.</p>
+	</section>
+	<footer class="dialog--actions">
+		<a class="button button--dialog" id="download-matches" title="Download matching results">Download
+			matches</a>
+		<button onclick="closeDialog('dialog-box')" class="button button--secondary button--dialog button--close">Close
+			this dialog</button>
+	</footer>
+</dialog>
+
+<div class="grid-row main-wrapper--lg">
+	<div class="grid-column-full">
+		<details>
+			<summary>Logging information</summary>
+			<table class="table">
+				<thead>
+					<tr>
+						<th width="50%">ID</th>
+						<th width="20%">Status</th>
+						<th width="30%">Result</th>
+					</tr>
+				</thead>
+				<tbody id="tasks">
+
+				</tbody>
+			</table>
+		</details>
+	</div>
+</div>
+{% endblock %}

--- a/app/templates/privacy-and-data.html
+++ b/app/templates/privacy-and-data.html
@@ -27,7 +27,7 @@
 			  <h1 class="page--heading">Privacy and data</h1>
 		  </div>
 		  <div class="grid-column-two-thirds">
-			  <p class="page--excerpt">This page explains the use of cookies on this website.</p>
+			  <p class="page--excerpt">This page explains the privacy and data policy for this website.</p>
 		  </div>
 	  </header>
   </div>

--- a/app/templates/privacy-and-data.html
+++ b/app/templates/privacy-and-data.html
@@ -10,34 +10,16 @@
   </li>
 {% endblock %}
 
+{% block pagecaption %}Mentor matcher{% endblock %}
+{% block pageheading %}Privacy and data{% endblock %}
+{% block pageexcerpt %}This page explains the privacy and data policy for this website.{% endblock %}
+
 {% block content %}
-
-<article class="article--news">
-
-	<div class="grid-row">
-	  <header class="page--header">
-		  <div class="grid-column-full">
-			  <span class="page--caption">Mentor matcher</span>
-			  <h1 class="page--heading">Privacy and data</h1>
-		  </div>
-		  <div class="grid-column-two-thirds">
-			  <p class="page--excerpt">This page explains the privacy and data policy for this website.</p>
-		  </div>
-	  </header>
-  </div>
-
 	<div class="grid-row">
 		<div class="grid-column-two-thirds">
-
 			<div class="page--content">
-
 				<p><i>Content here</i></p>
-        
 			</div>
-
 		</div>
 	</div>
-
-</article>
-
 {% endblock %}

--- a/app/templates/privacy-and-data.html
+++ b/app/templates/privacy-and-data.html
@@ -6,12 +6,6 @@
 
 {% block breadcrumbs %}
   <li class="breadcrumbs--list-item">
-    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt">Home</a>
-  </li>
-  <li class="breadcrumbs--list-item">
-    <a class="breadcrumbs--link" href="https://www.civilservice.lgbt/tools">Tools</a>
-  </li>
-  <li class="breadcrumbs--list-item">
     <a class="breadcrumbs--link" href="/">Mentor matcher</a>
   </li>
 {% endblock %}


### PR DESCRIPTION
Further to discussion on #49, this adds routes for a separate `start` and `match` page; with the former being the index.

Users are now presented with help text and a **Start now** button when starting the tool.

Note: this is a branch of #51 so they stay in sync. 6514346 is the first meaningful commit in this branch.