### PR TITLE
Bump package version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ kombu==5.2.3
 lettuce==0.2.23
 Mako==1.1.6
 MarkupSafe==2.0.1
-mentor-match==3.0.0
+mentor-match==4.0.1
 mock==4.0.3
 munkres==1.1.4
 mypy==0.910

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="1.0.0",
+    version="1.0.1",
     description="A web interface for the mentor-match-package",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This bumps the mentor-match package to 4.0.1.

The pckage now exposes a `Rule` object. In future versions we'll either need to create these on the web app and send them to the Celery worker as binary, or send some kind of json/dict to the worker and have a factory recreate the rules. However, at the moment the package maintainer (me) has kindly recreated the rules in the package, so the upshot is that nothing has changed for us

For now though, all tests pass. I've done a manual review as well and everything still seems to be working fine