### PR TITLE
Bump mentor match package 5.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = True
 tag = True
 

--- a/.github/workflows/trunk-dev.yml
+++ b/.github/workflows/trunk-dev.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Compose environment
         run: docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
       - name: Test
-        run: docker-compose exec -T app pytest tests -m integration --cache-clear --cov=app tests/ > pytest-coverage.txt
+        run: docker-compose exec -T app pytest tests -m integration --cache-clear --cov-apend --cov=app tests/ > pytest-coverage.txt
 
       - name: Stop docker
         if: ${{ env.ACT }}

--- a/.github/workflows/trunk-dev.yml
+++ b/.github/workflows/trunk-dev.yml
@@ -5,7 +5,7 @@ on:
 env:
   REDIS_URL: redis@redis
 jobs:
-  unit-test:
+  well-written-test:
     runs-on: ubuntu-20.04
 
     steps:
@@ -27,15 +27,9 @@ jobs:
       - name: Test with flake8
         run: flake8 --max-line-length=131 --extend-ignore=E203 tests/ app/
 
-      - name: Test with pytest and generate coverage
-        run: |
-          pytest -m unit --cache-clear --cov=app tests/ > pytest-coverage.txt
-
-      - name: Comment coverage
-        uses: coroo/pytest-coverage-commentator@v1.0.2
 
   get-commit-tag:
-    needs: unit-test
+    needs: well-written-test
     runs-on: ubuntu-20.04
     outputs:
       image_commit_tag: ${{ steps.vars.outputs.image_commit_tag }}
@@ -50,7 +44,7 @@ jobs:
           echo "::set-output name=image_commit_tag::$(git rev-parse --short HEAD)"
 
 
-  integration-tests:
+  all-tests:
     needs:
       - get-commit-tag
     env:
@@ -68,8 +62,12 @@ jobs:
 
       - name: Compose environment
         run: docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
-      - name: Test
-        run: docker-compose exec -T app pytest tests -m integration --cache-clear --cov-apend --cov=app tests/ > pytest-coverage.txt
+
+      - name: Full test suite
+        run: docker-compose exec -T app pytest tests --cache-clear --cov=app tests/ > pytest-coverage.txt
+
+      - name: Comment coverage
+        uses: coroo/pytest-coverage-commentator@v1.0.2
 
       - name: Stop docker
         if: ${{ env.ACT }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
         args: [--experimental-string-processing]
@@ -22,7 +22,7 @@ repos:
         args: [--max-line-length=131, --extend-ignore=E203]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports, --install-types, --non-interactive]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Users can now edit the weightings, but only for specific attributes, and for the pre-existing calculation
 
+
+## [1.0.2] - 2022-04-15
+
+## Changed
+
+- There's now a mapping function to convert the csv file the CS LGBT+ network uses into the format required by the
+  underlying library. Remember to update this when the headings in the csv file change.
+
 ## [1.0.0] - 2022-03-12
 Welcome to version 1 of this interface to the mentor-matching project! Thanks to a change in the underlying package we use, we've had to make a bit of a tweak to the package. So we figured why not actually write a changelog for this, for the first time ever?
 

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -2,6 +2,24 @@ import string
 import random
 from typing import Union
 
+from matching.person import Person
+
+
+def grades() -> list[str]:
+    return [
+        "AA",
+        "AO",
+        "EO",
+        "HEO",
+        "SEO",
+        "Grade 7",
+        "Grade 6",
+        "SCS1",
+        "SCS2",
+        "SCS3",
+        "SCS4",
+    ]
+
 
 def valid_file(filename: str) -> bool:
     return "." in filename and filename.rsplit(".", 1)[1].lower() == "csv"
@@ -56,17 +74,17 @@ def form_to_library_mapping(
 
 
 def convert_grade_to_int(grade: str) -> int:
-    grades = [
-        "AA",
-        "AO",
-        "EO",
-        "HEO",
-        "SEO",
-        "Grade 7",
-        "Grade 6",
-        "SCS1",
-        "SCS2",
-        "SCS3",
-        "SCS4",
-    ]
-    return grades.index(grade)
+    return grades().index(grade)
+
+
+def make_participant_grade_human_readable(participant: Person) -> Person:
+    """
+    This function takes a participant and translates their grade, as well as all the grades pf their connections
+    :param participant:
+    :return:
+    """
+    participant.grade = grades()[participant.grade]
+    if len(participant.connections) != 0:
+        for connection in participant.connections:
+            connection.grade = grades()[connection.grade]
+    return participant

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,5 +1,6 @@
 import string
 import random
+from typing import Union
 
 
 def valid_file(filename: str) -> bool:
@@ -27,3 +28,45 @@ def valid_files(filenames: list[str]) -> bool:
 
 def random_string():
     return "".join(random.choice(string.ascii_lowercase) for _ in range(10))
+
+
+def form_to_library_mapping(
+    form_dict: dict[str, str], participant_type: str
+) -> dict[str, Union[str, int]]:
+    mapping = {
+        f"Do you want to sign up as a {participant_type}?": participant_type,
+        "Your first name": "first name",
+        "Your last name": "last name",
+        "Your Civil Service email address": "email",
+        "Your job title or role": "role",
+        "Your department or agency": "organisation",
+        "Your grade": "grade",
+        "Your profession": "current profession",
+    }
+    new_dict: dict[str, Union[str, int]] = {}
+    for key, value in form_dict.items():
+        if key in mapping:
+            if key == "Your grade":
+                new_dict[mapping[key]] = convert_grade_to_int(value)
+            else:
+                new_dict[mapping[key]] = value
+        else:
+            new_dict[key] = value
+    return new_dict
+
+
+def convert_grade_to_int(grade: str) -> int:
+    grades = [
+        "AA",
+        "AO",
+        "EO",
+        "HEO",
+        "SEO",
+        "Grade 7",
+        "Grade 6",
+        "SCS1",
+        "SCS2",
+        "SCS3",
+        "SCS4",
+    ]
+    return grades.index(grade)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -26,6 +26,7 @@ from matching.mentee import Mentee
 from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path, create_mailing_list
 from app.helpers import form_to_library_mapping as mapping_func
+from app.helpers import make_participant_grade_human_readable
 
 
 @main_bp.route("/", methods=["GET"])
@@ -151,6 +152,10 @@ def get_status(task_id):
             participants = [
                 ParticipantFactory.create_from_dict(participant_dict)
                 for participant_dict in matched_participant_list
+            ]
+            participants = [
+                make_participant_grade_human_readable(participant)
+                for participant in participants
             ]
             create_mailing_list(
                 participants,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -25,6 +25,7 @@ from matching.factory import ParticipantFactory
 from matching.mentee import Mentee
 from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path, create_mailing_list
+from app.helpers import form_to_library_mapping as mapping_func
 
 
 @main_bp.route("/", methods=["GET"])
@@ -111,11 +112,15 @@ def run_task():
 
     mentors = [
         mentor.to_dict()
-        for mentor in create_participant_list_from_path(Mentor, path_to_data=folder)
+        for mentor in create_participant_list_from_path(
+            Mentor, path_to_data=folder, mapping_func=mapping_func
+        )
     ]
     mentees = [
         mentee.to_dict()
-        for mentee in create_participant_list_from_path(Mentee, path_to_data=folder)
+        for mentee in create_participant_list_from_path(
+            Mentee, path_to_data=folder, mapping_func=mapping_func
+        )
     ]
     task = async_process_data.delay(
         (mentors, mentees),

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ kombu==5.2.3
 lettuce==0.2.23
 Mako==1.1.6
 MarkupSafe==2.0.1
-mentor-match==4.0.1
+mentor-match==5.1.0
 mock==4.0.3
 munkres==1.1.4
 mypy==0.910

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="1.0.1",
+    version="1.0.2",
     description="A web interface for the mentor-match-package",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from app.config import TestConfig
 from matching.mentee import Mentee
 from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path
+from app.helpers import form_to_library_mapping
 
 
 @pytest.fixture(scope="session")
@@ -102,8 +103,8 @@ def client(test_data_path):
 def test_participants(test_data_path, known_file):
     known_file(test_data_path, "mentee", 50)
     known_file(test_data_path, "mentor", 50)
-    create_participant_list_from_path(Mentee, test_data_path)
-    create_participant_list_from_path(Mentor, test_data_path)
+    create_participant_list_from_path(Mentee, test_data_path, form_to_library_mapping)
+    create_participant_list_from_path(Mentor, test_data_path, form_to_library_mapping)
     yield
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,7 @@ from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path
 
 from app.tasks.tasks import async_process_data
+from app.helpers import form_to_library_mapping
 
 
 @pytest.mark.integration
@@ -51,11 +52,15 @@ class TestIntegration:
         known_file(test_data_path, "mentor", 50)
         mentees = [
             mentee.to_dict()
-            for mentee in create_participant_list_from_path(Mentee, test_data_path)
+            for mentee in create_participant_list_from_path(
+                Mentee, test_data_path, form_to_library_mapping
+            )
         ]
         mentors = [
             mentor.to_dict()
-            for mentor in create_participant_list_from_path(Mentor, test_data_path)
+            for mentor in create_participant_list_from_path(
+                Mentor, test_data_path, form_to_library_mapping
+            )
         ]
         task = async_process_data.delay((mentors, mentees), [])
         while not task.state == "SUCCESS":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+import csv
 import os.path
 import pathlib
 import time
@@ -9,6 +10,7 @@ from matching.mentee import Mentee
 from matching.mentor import Mentor
 from matching.process import create_participant_list_from_path
 
+import app.helpers
 from app.tasks.tasks import async_process_data
 from app.helpers import form_to_library_mapping
 
@@ -100,6 +102,17 @@ class TestIntegration:
         assert pathlib.Path(
             os.path.join(current_app.config["UPLOAD_FOLDER"]), processing_id
         ).exists()
+        with open(
+            pathlib.Path(
+                os.path.join(current_app.config["UPLOAD_FOLDER"]),
+                processing_id,
+                "mentors-list.csv",
+            )
+        ) as csv_file:
+            reader = csv.DictReader(csv_file)
+            for row in reader:
+                assert row["grade"] in app.helpers.grades()
+                assert row.get("match 1 grade") in app.helpers.grades()
 
     def test_delete_route(self, client, known_file, test_data_path):
         for participant in ("mentor", "mentee"):


### PR DESCRIPTION
# Fixup breaking changes in 5.1.0

The idiot who maintains the underlying package for this service has decided to generalise it, despite all the work we've done together. This means that our csv is no longer the template for the entire library, and I've had to write a mapping function to convert our headings into what they expect. Very frustrating but can't be helped.

Users should not experience any degradation of the service. However, we may need to consider how best to move forwards with the creation of the spreadsheet and mailing list.

This change makes it our responsibility to turn the integers representing the grade to a human-readable string - which would be fine, if the library didn't also produce our spreadsheet, which needs to be human-readable. We'll need to take control of the spreadsheet, or prevail upon the maintainer to find some way for us to get a translating or mapping function into the processing.

## [1.0.2] - 2022-04-15

## Changed

- There's now a mapping function to convert the csv file the CS LGBT+ network uses into the format required by the
  underlying library. Remember to update this when the headings in the csv file change.