### PR TITLE
Don't match when mentee hasn't declared characteristic

### DIFF
--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -37,7 +37,8 @@ def async_process_data(
         ),
         rl.Generic(
             {True: 4, False: 0},
-            lambda match: match.mentee.characteristic in match.mentor.characteristics,
+            lambda match: match.mentee.characteristic in match.mentor.characteristics
+            and match.mentee.characteristic != "",
         ),
     ]
     all_rules = [base_rules for _ in range(3)]


### PR DESCRIPTION
This prevents a match scoring points when the mentee hasn't declared a characteristic. Without this change, people who declared no preference would be matched as highly as people who had a specific characteristic match, which seems wrong for this use case