### PR TITLE
Add options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Users can now edit the weightings, but only for specific attributes, and for the pre-existing calculation
 
+## [2.3.0]
+
+### Changed
+- The system now uses pickle under the hood, so please be careful - if you've not secured the connections between
+  the machines you're running this on you could really get yourself into trouble.
+- However, it has made it significantly faster - a single matching exercise is now down to just 40s, from a best of
+  97s when we were using JSON to serialize data.
+
+### Added
+
+- This is the big one. We've added functionality that will creep up an `UnmatchedBonus`. This functionality is
+  useful if you want to ensure everyone gets at least one mentor. It calculates a lot of values - one client is
+  calculating 37 different iterations of a three-round program, requiring 111 rounds of matching - so it takes a bit
+  longer to calculate. Exposing this functionality in the front end will be patched very soon, but in the meantime
+  dig around in the routes section or add a `"pairing": True` key-value pair to your JSON call to the appropriate
+  endpoint.
+- Given the huge amount of processing happening, this functionality takes a lot longer than you're expecting. It's
+  enough time to make several cups of tea - on my hardware, it's clocking in at around 7 or 8 minutes. That's a long
+  time to stare at the same screen. We'll be updating the frontend to give more feedback soon, but for the moment,
+  either check the logs from celery or accept that you'll be here a little while.
+
 ## [2.2.0] - 2022-05-26
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.9-slim-bullseye AS parent
 MAINTAINER CS LGBTQ+
-COPY ./app /app
 COPY ./requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
+COPY ./app /app
 
 FROM parent AS web
 CMD ["gunicorn", "app:create_app()"]

--- a/app/classes.py
+++ b/app/classes.py
@@ -28,7 +28,7 @@ class CSPerson(Person):
     def __init__(self, **kwargs):
         self.biography = kwargs.get("biography")
         self.both = True if kwargs.get("both mentor and mentee") == "yes" else False
-        self.map_input_to_model(kwargs)
+        kwargs = self.map_input_to_model(kwargs)
         super(CSPerson, self).__init__(**kwargs)
         self._connections: list[CSPerson] = []
 
@@ -44,18 +44,24 @@ class CSPerson(Person):
     def connections(self) -> list["CSPerson"]:
         return self._connections
 
+    @connections.setter
+    def connections(self, new_connections):
+        self._connections = new_connections
+
     @staticmethod
     def map_input_to_model(data: dict):
         data["role"] = data["job title"]
-        data["email"] = data["email address"]
+        data["email"] = data.get("email address", data.get("email"))
         data["grade"] = CSPerson.str_grade_to_val(data.get("grade", ""))
+        return data
 
     def map_model_to_output(self, data: dict):
         data["job title"] = data.pop("role")
-        data["email address"] = data.pop("email")
+        # data["email address"] = data.pop("email")
         data["grade"] = self.val_grade_to_str(int(data.get("grade", "0")))
         data["biography"] = self.biography
         data["both mentor and mentee"] = "yes" if self.both else "no"
+        return data
 
     def to_dict_for_output(self, depth=1) -> dict:
         return {

--- a/app/config.py
+++ b/app/config.py
@@ -16,4 +16,4 @@ class TestConfig(Config):
         "interval_max": 0.5,
     }
     if os.environ.get("REDIS_URL") is None:
-        os.environ["REDIS_URL"] = "redis@redis"
+        os.environ["REDIS_URL"] = "redis://localhost:6379/0"

--- a/app/config.py
+++ b/app/config.py
@@ -16,4 +16,4 @@ class TestConfig(Config):
         "interval_max": 0.5,
     }
     if os.environ.get("REDIS_URL") is None:
-        os.environ["REDIS_URL"] = "redis://localhost:6379/0"
+        os.environ["REDIS_URL"] = "redis@redis"

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -2,11 +2,12 @@ import os
 
 from celery import Celery
 
-celery = Celery(
-    "app",
+celery_app = Celery(
+    "celery_app",
     backend=os.environ["REDIS_URL"],
     broker=os.environ["REDIS_URL"],
     include=["app.tasks.tasks"],
     accept_content=["pickle", "json"],
     task_serializer="pickle",
+    result_serializer="pickle",
 )

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -8,4 +8,5 @@ celery = Celery(
     broker=os.environ["REDIS_URL"],
     include=["app.tasks.tasks"],
     accept_content=["pickle", "json"],
+    task_serializer="pickle",
 )

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -7,5 +7,4 @@ celery = Celery(
     backend=os.environ["REDIS_URL"],
     broker=os.environ["REDIS_URL"],
     include=["app.tasks.tasks"],
-    accept_content=["pickle", "json"],
 )

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -7,4 +7,5 @@ celery = Celery(
     backend=os.environ["REDIS_URL"],
     broker=os.environ["REDIS_URL"],
     include=["app.tasks.tasks"],
+    accept_content=["pickle", "json"],
 )

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,9 +1,11 @@
 import csv
+import functools
 import math
 import operator
 import pathlib
 import string
 import random
+
 import matching.rules.rule as rl
 
 
@@ -50,6 +52,7 @@ def random_string():
     return "".join(random.choice(string.ascii_lowercase) for _ in range(10))
 
 
+@functools.cache
 def known_file(path_to_file, role_type: str, quantity=50):
     padding_size = int(math.log10(quantity)) + 1
     pathlib.Path(path_to_file).mkdir(parents=True, exist_ok=True)

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -52,7 +52,7 @@ def random_string():
     return "".join(random.choice(string.ascii_lowercase) for _ in range(10))
 
 
-@functools.cache
+@functools.lru_cache
 def known_file(path_to_file, role_type: str, quantity=50):
     padding_size = int(math.log10(quantity)) + 1
     pathlib.Path(path_to_file).mkdir(parents=True, exist_ok=True)
@@ -79,12 +79,11 @@ def known_data(role_type: str):
         "grade": "EO" if role_type == "mentor" else "AA",
         "organisation": f"Department of {role_type.capitalize()}s",
         "biography": "Test biography",
+        "profession": "Policy",
     }
     if role_type == "mentor":
-        data["profession"] = "Policy"
         data["characteristics"] = "bisexual, transgender"
     elif role_type == "mentee":
-        data["target profession"] = "Policy"
         data["match with similar identity"] = "yes"
         data["identity to match"] = "bisexual"
     else:

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -4,7 +4,6 @@ import operator
 import pathlib
 import string
 import random
-from matching.rules.rule import AbstractRule
 import matching.rules.rule as rl
 
 
@@ -172,7 +171,7 @@ def random_file(role_type: str, quantity: int = 50):
         file_writer.writerows(rows)
 
 
-def base_rules() -> list[AbstractRule]:
+def base_rules() -> list[rl.Rule]:
     return [
         rl.Disqualify(
             lambda match: match.mentee.organisation == match.mentor.organisation
@@ -192,5 +191,4 @@ def base_rules() -> list[AbstractRule]:
             lambda match: match.mentee.characteristic in match.mentor.characteristics
             and match.mentee.characteristic != "",
         ),
-        rl.UnmatchedBonus(6),
     ]

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -107,8 +107,12 @@ def download(task_id):
 
 @main_bp.route("/tasks", methods=["POST"])
 def run_task():
+    """
+    This route only accepts JSON encoded requests
+    """
     current_app.logger.debug(request.get_json())
     data_folder = request.get_json()["data_folder"]
+    unmatched_value = request.form.get("unmatched_value", 6)
     folder = pathlib.Path(
         os.path.join(current_app.config["UPLOAD_FOLDER"], data_folder)
     )
@@ -132,9 +136,7 @@ def run_task():
             path_to_data=folder,
         )
     ]
-    task = async_process_data.delay(
-        (mentors, mentees),
-    )
+    task = async_process_data.delay(mentors, mentees, unmatched_value)
     return jsonify(task_id=task.id), 202
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -223,6 +223,10 @@ def tasks(task_id):
             status_code = 404
         return jsonify(), status_code
 
+@main_bp.route("/options")
+## This route will need fixing!
+def options():
+    return render_template("options.html")
 
 @main_bp.route("/process", methods=["GET"])
 def process():

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -150,7 +150,7 @@ def get_status(task_id):
     }
     if task_result.status == "SUCCESS":
         outputs = {}
-        for participants in task_result.result:
+        for participants in task_result.result[:2]:
             participant_class = participants[0].class_name()
             connections = [len(p.connections) for p in participants]
             outputs[participant_class] = {

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -122,20 +122,14 @@ def run_task():
         shutil.rmtree(folder)
         return response
 
-    mentors = [
-        mentor.to_dict()
-        for mentor in create_participant_list_from_path(
-            CSMentor,
-            path_to_data=folder,
-        )
-    ]
-    mentees = [
-        mentee.to_dict()
-        for mentee in create_participant_list_from_path(
-            CSMentee,
-            path_to_data=folder,
-        )
-    ]
+    mentors = create_participant_list_from_path(
+        CSMentor,
+        path_to_data=folder,
+    )
+    mentees = create_participant_list_from_path(
+        CSMentee,
+        path_to_data=folder,
+    )
     task = async_process_data.delay(mentors, mentees, unmatched_value)
     return jsonify(task_id=task.id), 202
 

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,14 +1,14 @@
-from app.extensions import celery
+from app.extensions import celery_app
 
 
 def make_celery(app):
-    celery.conf.update(app.config)
-    celery.conf.imports = ("app.tasks.tasks",)
+    celery_app.conf.update(app.config)
+    celery_app.conf.imports = ("app.tasks.tasks",)
 
-    class ContextTask(celery.Task):
+    class ContextTask(celery_app.Task):
         def __call__(self, *args, **kwargs):
             with app.app_context():
                 return self.run(*args, **kwargs)
 
-    celery.Task = ContextTask
-    return celery
+    celery_app.Task = ContextTask
+    return celery_app

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -1,7 +1,5 @@
 import os
 import sys
-from copy import deepcopy
-import celery
 import requests
 from typing import Tuple, List, Sequence
 
@@ -28,19 +26,6 @@ def async_process_data(
         list(mentors), list(mentees), all_rules=all_rules
     )
     return matched_mentors, matched_mentees, unmatched_bonus
-
-
-@celery_app.task(bind=True)
-def process_data_with_floor(
-    self, mentors: list[CSMentor], mentees: list[CSMentee], floor=0.7
-):
-    max_score = sum(rule.results.get(True) for rule in base_rules())
-    copies = [(deepcopy(mentors), deepcopy(mentees), i) for i in range(max_score)]
-    # group = celery.group(async_process_data.si(*data) for data in copies)
-    chord = celery.chord(
-        (async_process_data.si(*data) for data in copies), find_best_output.s()
-    )
-    return chord()
 
 
 @celery_app.task

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -17,14 +17,14 @@ def async_process_data(
     mentors,
     mentees,
     unmatched_bonus: int = 6,
-) -> Tuple[List[CSMentor], List[CSMentee]]:
+) -> Tuple[List[CSMentor], List[CSMentee], int]:
     all_rules = [base_rules() for _ in range(3)]
     for ruleset in all_rules:
         ruleset.append(UnmatchedBonus(unmatched_bonus))
     matched_mentors, matched_mentees = process.process_data(
         list(mentors), list(mentees), all_rules=all_rules
     )
-    return matched_mentors, matched_mentees
+    return matched_mentors, matched_mentees, unmatched_bonus
 
 
 @celery_app.task(bind=True)
@@ -54,7 +54,7 @@ def find_best_output(group_result: Sequence[tuple[list[CSMentor], list[CSMentee]
             best_outcome = participant_tuple
             highest = total_mentors
     if not best_outcome:
-        best_outcome = group_result[0]
+        best_outcome = group_result[0][:2]
     return best_outcome
 
 

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -2,7 +2,7 @@ import os
 from copy import deepcopy
 import celery
 import requests
-from typing import Tuple, List
+from typing import Tuple, List, Sequence
 
 from app.classes import CSMentor, CSMentee
 from app.extensions import celery_app as celery_app
@@ -43,7 +43,7 @@ def process_data_with_floor(
 
 
 @celery_app.task
-def find_best_output(group_result: celery.Celery.GroupResult):
+def find_best_output(group_result: Sequence[tuple[list[CSMentor], list[CSMentee]]]):
     highest = 0
     best_outcome = None
     for participant_tuple in group_result:
@@ -53,6 +53,8 @@ def find_best_output(group_result: celery.Celery.GroupResult):
         if total_mentors > highest:
             best_outcome = participant_tuple
             highest = total_mentors
+    if not best_outcome:
+        best_outcome = group_result[0]
     return best_outcome
 
 

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -1,23 +1,22 @@
 import os
 
+import celery
 import requests
 from typing import Tuple, List
-from app.extensions import celery
+from app.extensions import celery as celery_app
 from matching import process
-from app.classes import CSParticipantFactory
 from app.helpers import base_rules
 from matching.rules.rule import UnmatchedBonus
 
 
-@celery.task(name="async_process_data", bind=True)
+@celery.shared_task
+@celery_app.task(name="async_process_data", bind=True, serializer="pickle")
 def async_process_data(
     self,
-    mentor_data,
-    mentee_data,
+    mentors,
+    mentees,
     unmatched_bonus: int = 6,
 ) -> Tuple[List[dict], List[dict]]:
-    mentors = map(CSParticipantFactory.create_from_dict, mentor_data)
-    mentees = map(CSParticipantFactory.create_from_dict, mentee_data)
     all_rules = [base_rules() for _ in range(3)]
     for ruleset in all_rules:
         ruleset.append(UnmatchedBonus(unmatched_bonus))
@@ -30,7 +29,7 @@ def async_process_data(
     return matched_as_dict
 
 
-@celery.task(name="delete_mailing_lists_after_period", bind=True)
+@celery_app.task(name="delete_mailing_lists_after_period", bind=True)
 def delete_mailing_lists_after_period(self, task_id: str):
     url = f"{os.environ.get('SERVICE_URL', 'http://app:5000')}/tasks/{task_id}"
     return requests.delete(url).status_code

--- a/app/templates/options.html
+++ b/app/templates/options.html
@@ -1,0 +1,58 @@
+{% extends 'page-with-header.html' %}
+{% block title %}Choose options{% endblock %}
+{% block head %}{{ super() }}{% endblock %}
+
+{% block breadcrumbs %}
+  <li class="breadcrumbs--list-item">
+    <a class="breadcrumbs--link" href="/">Mentor matcher</a>
+  </li>
+{% endblock %}
+
+{% block pagecaption %}Mentor matcher{% endblock %}
+{% block pageheading %}Options{% endblock %}
+{% block pageexcerpt %}Choose how mentors and mentees are matched.{% endblock %}
+
+{%  block content %}
+<div class="grid-row">
+  <div class="grid-column-two-thirds" id="options">
+    
+    <form method=post enctype=multipart/form-data action="">
+      {% if error_message %}
+        <blockquote class="error warning-text">
+          <p><strong>An error has occurred</strong></p>
+          <p>{{ error_message }}</p>
+        </blockquote>
+      {% endif %}
+      <div class="form-group">
+        
+        <fieldset id="fieldset-outcomes" aria-describedby="fieldset-outcomes--title" class="fieldset">
+            <legend id="fieldset-outcomes--title" class="legend-md">
+              Weightings
+            </legend>
+            
+            <div class="radios">
+              
+              <div class="radios--item">
+                  <input class="radios--input" id="radios--outcomes--higher-quality-matches" name="radios--outcomes" type="radio" value="quality" checked>
+                  <label class="radios--label" for="radios--outcomes--higher-quality-matches">
+                    <strong>Optimise for the best possible matches</strong>
+                  </label>
+                  <p class="hint radios--hint">This is the fastest option. Some mentees might not receive a match.</p>
+              </div>
+              
+              <div class="radios--item">
+                  <input class="radios--input" id="radios--outcomes--fewer-unmatched-mentees" name="radios--outcomes" type="radio" value="quantity">
+                  <label class="radios--label" for="radios--outcomes--fewer-unmatched-mentees">
+                      <strong>Optimise so that the most number of mentees receive a match</strong>
+                  </label>
+                  <p class="hint radios--hint">This is a slower option but will mean more mentees receive a match than the default.</p>
+              </div>
+            
+        </fieldset>
+        
+      </div>
+      <input type="submit" class="button button--action" value="Set these options ❯">
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -16,8 +16,12 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="matching">
     
-    <!-- insert options here -->
-
+    <p>You have selected the following options:</p>
+    
+    <ul style="margin-bottom: 45px;">
+      <li><!-- a description of the option chosen --></li>
+    </ul>  
+      
     <button id="match-button" class="button button--action" type="button" onclick="handleClick('{{ data_folder }}')">Start matching</button>
   </div>
 </div>

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -15,6 +15,8 @@
 {%  block content %}
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="matching">
+    
+    <!-- insert options here -->
 
     <button id="match-button" class="button button--action" type="button" onclick="handleClick('{{ data_folder }}')">Start matching</button>
   </div>

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -18,9 +18,11 @@
     
     <p>You have selected the following options:</p>
     
-    <ul style="margin-bottom: 45px;">
+    <ul>
       <li><!-- a description of the option chosen --></li>
-    </ul>  
+    </ul>
+    
+    <p style="margin-bottom: 45px;">If these options are correct, start the matching process using the button below. Otherwise, <a href="/options" title="Go back to the options page">go back and change these options</a>.</p>
       
     <button id="match-button" class="button button--action" type="button" onclick="handleClick('{{ data_folder }}')">Start matching</button>
   </div>

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,6 +5,3 @@ services:
     environment:
       - ENV=${ENV}
       - GH_IMAGE_COMMIT_TAG=${GH_IMAGE_COMMIT_TAG}
-
-  worker:
-    image: worker:${GH_IMAGE_COMMIT_TAG}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,3 +5,6 @@ services:
     environment:
       - ENV=${ENV}
       - GH_IMAGE_COMMIT_TAG=${GH_IMAGE_COMMIT_TAG}
+
+  worker:
+    image: worker:${GH_IMAGE_COMMIT_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     command: flask run -h 0.0.0.0
 
   worker:
+    user: nobody
     build:
       context: "."
       target: worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: "."
       target: worker
-    command: celery --app=app.extensions.celery worker --loglevel=info
+    command: celery --app=app.extensions.celery_app worker --loglevel=info
 
     environment:
       - FLASK_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,11 +26,10 @@ services:
     command: flask run -h 0.0.0.0
 
   worker:
-    user: nobody
     build:
       context: "."
       target: worker
-    command: celery --app=app.extensions.celery worker --loglevel=info --concurrency=10
+    command: celery --app=app.extensions.celery worker --loglevel=info
 
     environment:
       - FLASK_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,11 @@ services:
     command: flask run -h 0.0.0.0
 
   worker:
+    user: nobody
     build:
       context: "."
       target: worker
-    command: celery --app=app.extensions.celery worker --loglevel=info
+    command: celery --app=app.extensions.celery worker --loglevel=info --concurrency=10
 
     environment:
       - FLASK_ENV=development

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,3 +98,12 @@ def write_test_file(test_data_path):
         f.close()
 
     return _write_test_file
+
+
+@pytest.fixture(scope="session")
+def celery_config():
+    return {
+        "broker_url": "redis://redis:6379/0",
+        "result_backend": "redis://redis:6379/0",
+        "accept_content": ["pickle", "json"],
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-from typing import Mapping, Any
 
 import pytest as pytest
 import app.helpers
@@ -108,23 +107,4 @@ def celery_config():
         "broker_url": "redis://redis:6379/0",
         "result_backend": "redis://redis:6379/0",
         "accept_content": ["pickle", "json"],
-    }
-
-
-@pytest.fixture
-def celery_worker_parameters():
-    # type: () -> Mapping[str, Any]
-    """Redefine this fixture to change the init parameters of Celery workers.
-
-    This can be used e. g. to define queues the worker will consume tasks from.
-
-    The dict returned by your fixture will then be used
-    as parameters when instantiating :class:`~celery.worker.WorkController`.
-    """
-    return {
-        # For some reason this `celery.ping` is not registed IF our own worker is still
-        # running. To avoid failing tests in that case, we disable the ping check.
-        # see: https://github.com/celery/celery/issues/3642#issuecomment-369057682
-        # here is the ping task: `from celery.contrib.testing.tasks import ping`
-        "perform_ping_check": False,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,4 +110,5 @@ def celery_config():
         "result_backend": "redis://redis:6379/0",
         "accept_content": ["pickle", "json"],
         "task_serializer": "pickle",
+        "result_serializer": "pickle",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,11 +75,14 @@ def client(test_data_path):
 
 @pytest.fixture(scope="function")
 def test_participants(test_data_path, known_file):
-    known_file(test_data_path, "mentee", 50)
-    known_file(test_data_path, "mentor", 50)
-    create_participant_list_from_path(CSMentee, test_data_path)
-    create_participant_list_from_path(CSMentor, test_data_path)
-    yield
+    def _test_participants() -> tuple[list[CSMentor], list[CSMentee]]:
+        known_file(test_data_path, "mentee", 50)
+        known_file(test_data_path, "mentor", 50)
+        return create_participant_list_from_path(
+            CSMentor, test_data_path
+        ), create_participant_list_from_path(CSMentee, test_data_path)
+
+    return _test_participants
 
 
 @pytest.fixture(autouse=True)
@@ -106,8 +109,8 @@ def write_test_file(test_data_path):
 def celery_config():
     logging.debug("CALLED!")
     return {
-        "broker_url": "redis://redis:6379/0",
-        "result_backend": "redis://redis:6379/0",
+        "broker_url": "redis://localhost:6379/0",
+        "result_backend": "redis://localhost:6379/0",
         "accept_content": ["pickle", "json"],
         "task_serializer": "pickle",
         "result_serializer": "pickle",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 
@@ -101,10 +102,12 @@ def write_test_file(test_data_path):
     return _write_test_file
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def celery_config():
+    logging.debug("CALLED!")
     return {
         "broker_url": "redis://redis:6379/0",
         "result_backend": "redis://redis:6379/0",
         "accept_content": ["pickle", "json"],
+        "task_serializer": "pickle",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,12 +98,3 @@ def write_test_file(test_data_path):
         f.close()
 
     return _write_test_file
-
-
-@pytest.fixture(scope="session")
-def celery_config():
-    return {
-        "broker_url": "redis://redis:6379/0",
-        "result_backend": "redis://redis:6379/0",
-        "accept_content": ["pickle", "json"],
-    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,14 +75,11 @@ def client(test_data_path):
 
 @pytest.fixture(scope="function")
 def test_participants(test_data_path, known_file):
-    def _test_participants() -> tuple[list[CSMentor], list[CSMentee]]:
-        known_file(test_data_path, "mentee", 50)
-        known_file(test_data_path, "mentor", 50)
-        return create_participant_list_from_path(
-            CSMentor, test_data_path
-        ), create_participant_list_from_path(CSMentee, test_data_path)
-
-    return _test_participants
+    known_file(test_data_path, "mentee", 50)
+    known_file(test_data_path, "mentor", 50)
+    create_participant_list_from_path(CSMentee, test_data_path)
+    create_participant_list_from_path(CSMentor, test_data_path)
+    yield
 
 
 @pytest.fixture(autouse=True)
@@ -109,8 +106,8 @@ def write_test_file(test_data_path):
 def celery_config():
     logging.debug("CALLED!")
     return {
-        "broker_url": "redis://localhost:6379/0",
-        "result_backend": "redis://localhost:6379/0",
+        "broker_url": "redis://redis:6379/0",
+        "result_backend": "redis://redis:6379/0",
         "accept_content": ["pickle", "json"],
         "task_serializer": "pickle",
         "result_serializer": "pickle",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,9 @@ from app.helpers import known_data
 
 @pytest.fixture(scope="function")
 def base_data() -> dict:
+    """
+    This is a `dict` representation of the data in the CSV file presented to the system
+    """
     return {
         "first name": "Test",
         "last name": "Data",
@@ -37,7 +40,6 @@ def base_mentor_data(base_data):
 
 @pytest.fixture
 def base_mentee_data(base_data):
-    base_data["profession"] = "Policy"
     base_data["match with similar identity"] = "yes"
     base_data["identity to match"] = "bisexual"
     return base_data
@@ -112,6 +114,14 @@ def celery_config():
         "accept_content": ["pickle", "json"],
         "task_serializer": "pickle",
         "result_serializer": "pickle",
+    }
+
+
+@pytest.fixture(scope="session")
+def celery_worker_parameters():
+    return {
+        # 'queues': ('default'),
+        "perform_ping_check": False
     }
 
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -3,6 +3,7 @@ import pytest
 from app.classes import CSMentor, CSMentee, CSParticipantFactory
 from matching.rules import rule as rl
 from matching.match import Match
+import pickle
 
 
 @pytest.mark.unit
@@ -15,7 +16,6 @@ def test_CSMentor_to_dict(base_data):
 
 @pytest.mark.unit
 def test_CSMentee_to_dict(base_data):
-    base_data["target profession"] = base_data.get("profession")
     mentor = CSMentee(**base_data)
     for key, value in base_data.items():
         assert value in mentor.to_dict()[mentor.class_name()].values()
@@ -61,3 +61,12 @@ def test_export(base_mentor, base_mentee, base_mentor_data):
         "mentor only": "yes",
         "number of matches": 2,
     }
+
+
+@pytest.mark.unit
+def test_class_is_picklable(base_mentor, base_mentee):
+    base_mentor.mentees = base_mentee
+    base_mentee.mentors = base_mentor
+    pickled = pickle.dumps(base_mentor)
+    unpickled_mentor = pickle.loads(pickled)
+    assert unpickled_mentor == base_mentor

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,15 +47,10 @@ class TestIntegration:
     def test_process_data(self, celery_app, celery_worker, known_file, test_data_path):
         known_file(test_data_path, "mentee", 50)
         known_file(test_data_path, "mentor", 50)
-        mentees = [
-            mentee.to_dict()
-            for mentee in create_participant_list_from_path(CSMentee, test_data_path)
-        ]
-        mentors = [
-            mentor.to_dict()
-            for mentor in create_participant_list_from_path(CSMentor, test_data_path)
-        ]
-        task = async_process_data.delay(mentors, mentees)
+        task = async_process_data.delay(
+            create_participant_list_from_path(CSMentor, test_data_path),
+            create_participant_list_from_path(CSMentee, test_data_path),
+        )
         while not task.state == "SUCCESS":
             time.sleep(1)
         assert len(task.result[0]) == 50
@@ -71,7 +66,6 @@ class TestIntegration:
         output,
         client,
     ):
-        print(celery_app)
         known_file(pathlib.Path(test_data_path, test_task), "mentee", output)
         known_file(pathlib.Path(test_data_path, test_task), "mentor", output)
         processing_id = client.post(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,11 +74,6 @@ class TestIntegration:
 
         resp = client.get(url_for("main.get_status", task_id=processing_id))
         content = resp.get_json()
-        assert content == {
-            "task_id": processing_id,
-            "task_status": "PENDING",
-            "task_result": "processing",
-        }
         assert resp.status_code == 200
         current_app.config["UPLOAD_FOLDER"] = test_data_path
         while content["task_status"] == "PENDING":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,8 +18,6 @@ class TestIntegration:
         self,
         test_participants,
         test_data_path,
-        celery_worker,
-        celery_app,
         client,
     ):
         src_file_paths = (
@@ -73,6 +71,7 @@ class TestIntegration:
         output,
         client,
     ):
+        print(celery_app)
         known_file(pathlib.Path(test_data_path, test_task), "mentee", output)
         known_file(pathlib.Path(test_data_path, test_task), "mentor", output)
         processing_id = client.post(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,7 +57,7 @@ class TestIntegration:
             mentor.to_dict()
             for mentor in create_participant_list_from_path(CSMentor, test_data_path)
         ]
-        task = async_process_data.delay((mentors, mentees))
+        task = async_process_data.delay(mentors, mentees)
         while not task.state == "SUCCESS":
             time.sleep(1)
         assert len(task.result[0]) == 50

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -30,7 +30,5 @@ def test_delete_calls_correct_path():
 
 
 @pytest.mark.unit
-def test_async_process_data(base_mentee_data, base_mentor_data):
-    assert async_process_data(
-        [{"csmentor": base_mentor_data}], [{"csmentee": base_mentee_data}]
-    )
+def test_async_process_data(base_mentee, base_mentor):
+    assert async_process_data([base_mentor], [base_mentee])

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -50,7 +50,7 @@ def test_async_floor(base_mentor, base_mentee, celery_app, celery_worker):
 def test_find_best_outcome(base_mentor, base_mentee):
     base_mentor.mentees = base_mentee
     base_mentee.mentors = base_mentor
-    assert find_best_output([([base_mentor], [base_mentee])]) == (
+    assert find_best_output([([base_mentor], [base_mentee], 0)]) == (
         [base_mentor],
         [base_mentee],
     )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -7,6 +7,7 @@ from app.tasks.tasks import (
     delete_mailing_lists_after_period,
     async_process_data,
     process_data_with_floor,
+    find_best_output,
 )
 
 
@@ -38,7 +39,18 @@ def test_async_process_data(base_mentee, base_mentor):
     assert async_process_data([base_mentor], [base_mentee])
 
 
-def test_async_floor(test_participants, celery_app, celery_worker):
-    res = process_data_with_floor(*test_participants(50))
+@pytest.mark.integration
+def test_async_floor(base_mentor, base_mentee, celery_app, celery_worker):
+    res = process_data_with_floor([base_mentor], [base_mentee])
     a = res.get()
     assert len(a) == 2
+
+
+@pytest.mark.unit
+def test_find_best_outcome(base_mentor, base_mentee):
+    base_mentor.mentees = base_mentee
+    base_mentee.mentors = base_mentor
+    assert find_best_output([([base_mentor], [base_mentee])]) == (
+        [base_mentor],
+        [base_mentee],
+    )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -38,5 +38,7 @@ def test_async_process_data(base_mentee, base_mentor):
     assert async_process_data([base_mentor], [base_mentee])
 
 
-def test_async_floor(base_mentee, base_mentor):
-    assert process_data_with_floor([base_mentor], [base_mentee]) == 5
+def test_async_floor(test_participants, celery_app, celery_worker):
+    res = process_data_with_floor(*test_participants(50))
+    a = res.get()
+    assert len(a) == 2

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -3,7 +3,11 @@ from unittest.mock import patch, Mock, MagicMock
 
 import pytest
 from flask import url_for, session
-from app.tasks.tasks import delete_mailing_lists_after_period, async_process_data
+from app.tasks.tasks import (
+    delete_mailing_lists_after_period,
+    async_process_data,
+    process_data_with_floor,
+)
 
 
 @pytest.mark.unit
@@ -32,3 +36,7 @@ def test_delete_calls_correct_path():
 @pytest.mark.unit
 def test_async_process_data(base_mentee, base_mentor):
     assert async_process_data([base_mentor], [base_mentee])
+
+
+def test_async_floor(base_mentee, base_mentor):
+    assert process_data_with_floor([base_mentor], [base_mentee]) == 5

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -31,5 +31,6 @@ def test_delete_calls_correct_path():
 
 @pytest.mark.unit
 def test_async_process_data(base_mentee_data, base_mentor_data):
-    test_data = ([{"csmentor": base_mentor_data}], [{"csmentee": base_mentee_data}])
-    assert async_process_data(data_to_process=test_data)
+    assert async_process_data(
+        [{"csmentor": base_mentor_data}], [{"csmentee": base_mentee_data}]
+    )


### PR DESCRIPTION
This adds:

- a new route (that doesn't work!) for an `/options` page
- a page template for the `/options` page
- an amendment to the `/process` page that could usefully show the option people selected (but needs a way to know what that is from the router!)

@jonodrew does that do enough to help? Not really sure what else to add as the Python is beyond me!