### PR TITLE
Add options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Users can now edit the weightings, but only for specific attributes, and for the pre-existing calculation
 
+## [2.3.1] - 2022-06-20
+
+### Added
+
+- This release adds an interface exposing the functionality we built in 2.3.0
+
 ## [2.3.0] - 2022-06-19
 
 ### Changed

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -217,11 +217,13 @@ def tasks(task_id):
             status_code = 404
         return jsonify(), status_code
 
+
 @main_bp.route("/options")
 # This route will need fixing!
 def options():
     return render_template("options.html")
-             
+
+
 @main_bp.route("/process", methods=["GET"])
 def process():
     data_folder = request.cookies.get("data-folder")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -61,7 +61,7 @@ def upload():
                 file.save(
                     os.path.join(current_app.config["UPLOAD_FOLDER"], folder, filename)
                 )
-            response = make_response(redirect(url_for("main.process")))
+            response = make_response(redirect(url_for("main.options")))
             response.set_cookie(
                 "data-folder",
                 folder,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -218,19 +218,31 @@ def tasks(task_id):
         return jsonify(), status_code
 
 
-@main_bp.route("/options")
-# This route will need fixing!
+@main_bp.route("/options", methods=["GET", "POST"])
 def options():
-    return render_template("options.html")
+    if request.method == "GET":
+        return render_template("options.html")
+    else:
+        matching_function = request.form.get("radios--outcomes", "quality")
+        response = make_response(redirect(url_for("main.process")))
+        response.set_cookie(
+            "matching_func",
+            matching_function,
+            expires=datetime.datetime.now() + timedelta(minutes=30),
+        )
+        return response
 
 
 @main_bp.route("/process", methods=["GET"])
 def process():
     data_folder = request.cookies.get("data-folder")
+    matching_function = request.cookies.get("matching_func")
     if not data_folder:
         return redirect(url_for("main.upload"))
     else:
-        return render_template("process.html", data_folder=data_folder)
+        return render_template(
+            "process.html", data_folder=data_folder, matching=matching_function
+        )
 
 
 @main_bp.route("/finished", methods=["GET"])

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -116,9 +116,9 @@ def run_task():
     current_app.logger.debug(request.get_json())
     data_folder = request.get_json()["data_folder"]
     try:
-        optimise_for_pairing = request.get_json()["pairing"]
+        matching_approach = request.get_json()["matching_function"]
     except KeyError:
-        optimise_for_pairing = False
+        matching_approach = "quality"
     folder = pathlib.Path(
         os.path.join(current_app.config["UPLOAD_FOLDER"], data_folder)
     )
@@ -136,7 +136,7 @@ def run_task():
         CSMentee,
         path_to_data=folder,
     )
-    if optimise_for_pairing:
+    if matching_approach == "quantity":
         task = most_mentees_with_at_least_one_mentor(mentors, mentees)
     else:
         task = async_process_data.delay(mentors, mentees)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -217,7 +217,11 @@ def tasks(task_id):
             status_code = 404
         return jsonify(), status_code
 
-
+@main_bp.route("/options")
+## This route will need fixing!
+def options():
+    return render_template("options.html")
+             
 @main_bp.route("/process", methods=["GET"])
 def process():
     data_folder = request.cookies.get("data-folder")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -218,7 +218,7 @@ def tasks(task_id):
         return jsonify(), status_code
 
 @main_bp.route("/options")
-## This route will need fixing!
+# This route will need fixing!
 def options():
     return render_template("options.html")
              

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,4 +1,4 @@
-function handleClick(data_folder) {
+function handleClick(data_folder, matching_function) {
 
   const matching = document.getElementById('matching');
 
@@ -10,7 +10,7 @@ function handleClick(data_folder) {
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ data_folder: data_folder }),
+    body: JSON.stringify({ data_folder: data_folder, matching_function: matching_function }),
   })
   .then(response => response.json())
   .then(data => getStatus(data.task_id));

--- a/app/templates/options.html
+++ b/app/templates/options.html
@@ -1,0 +1,60 @@
+{% extends 'page-with-header.html' %}
+{% block title %}Choose options{% endblock %}
+{% block head %}{{ super() }}{% endblock %}
+
+{% block breadcrumbs %}
+ <li class="breadcrumbs--list-item">
+   <a class="breadcrumbs--link" href="/">Mentor matcher</a>
+ </li>
+{% endblock %}
+
+{% block pagecaption %}Mentor matcher{% endblock %}
+{% block pageheading %}Options{% endblock %}
+{% block pageexcerpt %}Choose how mentors and mentees are matched.{% endblock %}
+
+{%  block content %}
+<div class="grid-row">
+  <div class="grid-column-two-thirds" id="options">
+  
+    <form method=post enctype=multipart/form-data action="">
+      {% if error_message %}
+      <blockquote class="error warning-text">
+        <p><strong>An error has occurred</strong></p>
+        <p>{{ error_message }}</p>
+      </blockquote>
+      {% endif %}
+      <div class="form-group">
+      
+        <fieldset id="fieldset-outcomes" aria-describedby="fieldset-outcomes--title" class="fieldset">
+          <legend id="fieldset-outcomes--title" class="legend-md">
+          Weightings
+          </legend>
+          
+          <div class="radios">
+          
+            <div class="radios--item">
+              <input class="radios--input" id="radios--outcomes--higher-quality-matches" name="radios--outcomes" type="radio" value="quality" checked>
+              <label class="radios--label" for="radios--outcomes--higher-quality-matches">
+              <strong>Optimise for the best possible matches</strong>
+              </label>
+              <p class="hint radios--hint">This is the fastest option. Some mentees might not receive a match.</p>
+            </div>
+            
+            <div class="radios--item">
+              <input class="radios--input" id="radios--outcomes--fewer-unmatched-mentees" name="radios--outcomes" type="radio" value="quantity">
+              <label class="radios--label" for="radios--outcomes--fewer-unmatched-mentees">
+              <strong>Optimise so that the most number of mentees receive a match</strong>
+              </label>
+              <p class="hint radios--hint">This is a slower option but will mean more mentees receive a match than the default.</p>
+            </div>
+          
+          </div>
+        
+        </fieldset>
+        
+      </div>
+      <input type="submit" class="button button--action" value="Set these options ❯">
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -14,17 +14,17 @@
 
 {%  block content %}
 <div class="grid-row">
-  <div class="grid-column-two-thirds" id="matching">    
-    
+  <div class="grid-column-two-thirds" id="matching">
+
     <p>You have selected the following options:</p>
-    
+
     <ul>
-      <li><!-- a description of the option chosen --></li>
+      <li><strong>{% if matching == "quality" %}Optimise for the best possible matches{% else %}Optimise so that the most number of mentees receive a match</strong>{% endif %}
     </ul>
-    
+
     <p style="margin-bottom: 45px;">If these options are correct, start the matching process using the button below. Otherwise, <a href="/options" title="Go back to the options page">go back and change these options</a>.</p>
 
-    <button id="match-button" class="button button--action" type="button" onclick="handleClick('{{ data_folder }}')">Start matching</button>
+    <button id="match-button" class="button button--action" type="button" onclick="handleClick('{{ data_folder }}', '{{ matching }}')">Start matching</button>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/process.html
+++ b/app/templates/process.html
@@ -14,7 +14,15 @@
 
 {%  block content %}
 <div class="grid-row">
-  <div class="grid-column-two-thirds" id="matching">
+  <div class="grid-column-two-thirds" id="matching">    
+    
+    <p>You have selected the following options:</p>
+    
+    <ul>
+      <li><!-- a description of the option chosen --></li>
+    </ul>
+    
+    <p style="margin-bottom: 45px;">If these options are correct, start the matching process using the button below. Otherwise, <a href="/options" title="Go back to the options page">go back and change these options</a>.</p>
 
     <button id="match-button" class="button button--action" type="button" onclick="handleClick('{{ data_folder }}')">Start matching</button>
   </div>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,7 +56,7 @@ class TestIntegration:
 
         assert len(mentors) == 50 and len(mentees) == 50
 
-    @pytest.mark.parametrize("testing_value", (True, False))
+    @pytest.mark.parametrize("testing_value", ("quantity", "quality"))
     @pytest.mark.parametrize(["test_task", "output"], [("small", 10), ("large", 100)])
     def test_create_mailing_list(
         self,

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -124,4 +124,4 @@ class TestUpload:
             content_type="multipart/form-data",
             follow_redirects=True,
         )
-        assert response.request.path == url_for("main.process")
+        assert response.request.path == url_for("main.options")


### PR DESCRIPTION
This adds a clean version of:

– a new route (that doesn't work!) for an /options page
– a page template for the /options page
– an amendment to the /process page that could usefully show the option people selected (but needs a way to know what that is from the router!)

<img width="854" alt="Screenshot 2022-06-19 at 19 40 23" src="https://user-images.githubusercontent.com/4903081/174499072-30376040-214a-4e46-8f41-2edd7df14802.png">