### PR TITLE
Add parallelization library

### DIFF
--- a/.github/workflows/trunk-dev.yml
+++ b/.github/workflows/trunk-dev.yml
@@ -64,7 +64,7 @@ jobs:
         run: docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 
       - name: Full test suite
-        run: docker-compose exec -T app pytest tests --cache-clear --cov=app tests/ > pytest-coverage.txt
+        run: docker-compose exec -T app pytest tests -n 3 --cache-clear --cov=app tests/ > pytest-coverage.txt
 
       - name: Comment coverage
         uses: coroo/pytest-coverage-commentator@v1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ click-repl==0.2.0
 coverage==6.3
 cryptography==36.0.1
 distlib==0.3.2
+execnet==1.9.0
 extras==1.0.0
 filelock==3.0.12
 fixtures==3.0.0
@@ -74,6 +75,8 @@ pytest==6.2.5
 pytest-bdd==5.0.0
 pytest-celery==0.0.0
 pytest-cov==3.0.0
+pytest-forked==1.4.0
+pytest-xdist==2.5.0
 python-dateutil==2.8.2
 python-subunit==1.4.0
 pytz==2021.3


### PR DESCRIPTION
This test suite is quite easy to parallelize, because there's no database so there's no state to be worrying about. This means we can ramp up the speed of the tests very easily