### PR TITLE
Notify participants

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.3
+current_version = 2.4.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Users can now edit the weightings, but only for specific attributes, and for the pre-existing calculation
 
+## [2.4.0] - 2022-06-26
+
+### Added
+
+- This change exposes a route that, on a `POST` request:
+  - reads a cookie `task-id`, which is the folder where the output is stored
+  - receives a form from the request, which has a `template-id`, a `reply-id`, a `service`, and an `api-key`
+  - the `service` defaults to Notify, so for the moment that choice doesn't need to be coded into the system
+  - it creates the appropriate client for the `service`, and then sends every participant, in both files in the
+    output folder, the `template-id` email using each row in the file as the personalisation
+  - the emails are handed off to Celery to take care of
+  - this does not yet take account of any other templates: for example, templates where no matches have been made.
+    These `template-id`s would need to be passed, somehow, from the frontend. Alternatively, a template could be
+    designed that comprises big `if ...then` blocks
+
+
+
 ## [2.3.3] - 2022-06-25
 
 ### Changed

--- a/app/export.py
+++ b/app/export.py
@@ -1,11 +1,4 @@
-from typing import Protocol
-
 from notifications_python_client import NotificationsAPIClient
-
-
-class Exporter(Protocol):
-    def send_email(self, recipient: str, **kwargs):
-        ...
 
 
 class NotifyClient(NotificationsAPIClient):
@@ -27,6 +20,6 @@ class ExportFactory:
     available_services = {"notify": NotifyClient}
 
     @classmethod
-    def create_exporter(cls, service_name: str, **kwargs) -> Exporter:
+    def create_exporter(cls, service_name: str, **kwargs):
         exporter_class = cls.available_services[service_name]
         return exporter_class(**kwargs)

--- a/app/export.py
+++ b/app/export.py
@@ -14,11 +14,11 @@ class NotifyClient(NotificationsAPIClient):
         self.template_id: str = kwargs.get("template-id")
         self.email_reply_to_id: str = kwargs.get("reply-id")
 
-    def send_email(self, recipient: str, **kwargs):
+    def send_email(self, recipient: str, **personalisation_data):
         self.send_email_notification(
             email_address=recipient,
             template_id=self.template_id,
-            personalisation=kwargs,
+            personalisation=personalisation_data,
             email_reply_to_id=self.email_reply_to_id,
         )
 

--- a/app/export.py
+++ b/app/export.py
@@ -1,0 +1,32 @@
+from typing import Protocol
+
+from notifications_python_client import NotificationsAPIClient
+
+
+class Exporter(Protocol):
+    def send_email(self, recipient: str, **kwargs):
+        ...
+
+
+class NotifyClient(NotificationsAPIClient):
+    def __init__(self, **kwargs):
+        super(NotifyClient, self).__init__(kwargs.get("api-key"))
+        self.template_id: str = kwargs.get("template-id")
+        self.email_reply_to_id: str = kwargs.get("reply-id")
+
+    def send_email(self, recipient: str, **kwargs):
+        self.send_email_notification(
+            email_address=recipient,
+            template_id=self.template_id,
+            personalisation=kwargs,
+            email_reply_to_id=self.email_reply_to_id,
+        )
+
+
+class ExportFactory:
+    available_services = {"notify": NotifyClient}
+
+    @classmethod
+    def create_exporter(cls, service_name: str, **kwargs) -> Exporter:
+        exporter_class = cls.available_services[service_name]
+        return exporter_class(**kwargs)

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -2,10 +2,12 @@ import csv
 import functools
 import math
 import operator
+import os
 import pathlib
 import string
 import random
 
+import flask
 import matching.rules.rule as rl
 
 
@@ -194,3 +196,9 @@ def base_rules() -> list[rl.Rule]:
             and match.mentee.characteristic != "",
         ),
     ]
+
+
+def get_data_folder_path(app_instance: flask.Flask, folder_name: str) -> pathlib.Path:
+    return pathlib.Path(
+        os.path.join(app_instance.config["UPLOAD_FOLDER"].strpath, folder_name)
+    )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -3,6 +3,7 @@ import json
 import os.path
 from datetime import timedelta
 
+import celery
 from flask import (
     make_response,
     render_template,
@@ -18,12 +19,14 @@ import shutil
 from werkzeug.utils import secure_filename, redirect
 
 from app.classes import CSMentor, CSMentee
+from app.export import ExportFactory
 from app.extensions import celery_app
 from app.main import main_bp
 from app.helpers import valid_files, random_string
 from app.tasks.tasks import (
     async_process_data,
     delete_mailing_lists_after_period,
+    send_notification,
 )
 from app.tasks.helpers import most_mentees_with_at_least_one_mentor
 from matching.process import create_participant_list_from_path, create_mailing_list

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -2,16 +2,20 @@ import functools
 import os
 import sys
 import requests
-from typing import Tuple, List, Sequence
+from typing import Tuple, List, Sequence, Protocol
 
 from app.classes import CSMentor, CSMentee
-from app.export import Exporter
 from app.extensions import celery_app as celery_app
 from matching import process
 from app.helpers import base_rules
 from matching.rules.rule import UnmatchedBonus
 
 sys.setrecursionlimit(10000)
+
+
+class Exporter(Protocol):
+    def send_email(self, recipient: str, **kwargs):
+        ...
 
 
 @celery_app.task(name="async_process_data", bind=True)

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -5,6 +5,7 @@ import requests
 from typing import Tuple, List, Sequence
 
 from app.classes import CSMentor, CSMentee
+from app.export import Exporter
 from app.extensions import celery_app as celery_app
 from matching import process
 from app.helpers import base_rules
@@ -61,3 +62,8 @@ def find_best_output(
 def delete_mailing_lists_after_period(self, task_id: str):
     url = f"{os.environ.get('SERVICE_URL', 'http://app:5000')}/tasks/{task_id}"
     return requests.delete(url).status_code
+
+
+@celery_app.task
+def send_notification(exporter: Exporter, participant_data: dict[str, str]):
+    return exporter.send_email(participant_data.get("email", ""), **participant_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,6 +100,7 @@ tox==3.24.4
 trio==0.19.0
 trio-websocket==0.9.2
 types-freezegun==1.1.6
+types-mock==4.0.15
 types-requests==2.27.10
 types-urllib3==1.26.9
 typing-extensions==3.10.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ click-repl==0.2.0
 coverage==6.3
 cryptography==36.0.1
 distlib==0.3.2
+docopt==0.6.2
 execnet==1.9.0
 extras==1.0.0
 filelock==3.0.12
@@ -53,6 +54,7 @@ munkres==1.1.4
 mypy==0.910
 mypy-extensions==0.4.3
 nodeenv==1.6.0
+notifications-python-client==6.3.0
 oauthlib==3.1.1
 outcome==1.1.0
 packaging==21.0
@@ -69,6 +71,7 @@ py==1.10.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
+PyJWT==2.4.0
 pyOpenSSL==22.0.0
 pyparsing==2.4.7
 pytest==6.2.5

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="2.3.3",
+    version="2.4.0",
     description="A web interface for the mentor-match-package",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,26 @@
+import pytest
+from app.export import NotifyClient, ExportFactory
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ["service_name", "form_data", "expected_client"],
+    (
+        [
+            "notify",
+            {
+                "api-key": "".join(str(_) for _ in range(100)),
+                "template-id": "12345",
+                "reply-id": "reply-to-me",
+            },
+            NotifyClient,
+        ],
+    ),
+)
+def test_export_factory_create_clients_correctly(
+    service_name, form_data, expected_client
+):
+    assert (
+        ExportFactory.create_exporter(service_name, **form_data).__dict__
+        == expected_client(**form_data).__dict__
+    )

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -1,0 +1,2 @@
+def test_notify_route_reads_all_user_data():
+    assert False

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -70,3 +70,14 @@ class TestNotifyRoute:
             },
         )
         assert response.status_code == 404
+
+    @pytest.mark.unit
+    def test_route_raises_error_if_bad_api_key(self, client):
+        response = client.post(
+            url_for("main.notify_participants"),
+            data={
+                "service": "notify",
+                "api-key": "".join(str(_) for _ in range(10)),
+            },
+        )
+        assert response.status_code == 400

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -59,3 +59,14 @@ class TestNotifyRoute:
                 assert len(calls) == 10
                 notification_args = patched_notification.call_args
                 assert notification_args[1] == {}
+
+    @pytest.mark.unit
+    def test_notify_route_raises_404_if_no_data(self, notify_client):
+        response = notify_client.post(
+            url_for("main.notify_participants"),
+            data={
+                "service": "notify",
+                "api-key": "".join(str(_) for _ in range(100)),
+            },
+        )
+        assert response.status_code == 404

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -1,17 +1,33 @@
 from unittest.mock import patch
+import mock
 import pytest
 from flask import url_for
+
+
+@pytest.fixture
+def notify_client(client):
+    client.set_cookie(server_name="localhost", key="task-id", value="data")
+    yield client
+
+
+@pytest.fixture
+def patch_open_file():
+    data = mock.mock_open(read_data="first,second,third")
+    with patch(target="app.main.routes.open", new=data):
+        yield
 
 
 class TestNotifyRoute:
     @pytest.mark.unit
     @patch("app.main.routes.ExportFactory", autospec=True)
-    def test_when_route_passed_form_creates_exporter(self, patched_factory, client):
-        patch("app.main.routes.celery.group").start()
-        client.set_cookie(server_name="localhost", key="data-folder", value="test")
-        with patch.object(patched_factory, "create_exporter") as patched_creator:
-            client.post(url_for("main.notify_participants"), data={"service": "notify"})
-            patched_creator.assert_called_with("notify")
-
-    def test_notify_route_reads_all_user_data(self):
-        assert False
+    def test_when_route_passed_form_creates_exporter(
+        self, patched_factory, client, patch_open_file
+    ):
+        with patch("app.main.routes.celery.group"):
+            with patch.object(patched_factory, "create_exporter") as patched_creator:
+                client.post(
+                    url_for("main.notify_participants"), data={"service": "notify"}
+                )
+                patched_creator.assert_called_with(
+                    "notify",
+                )

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -1,2 +1,17 @@
-def test_notify_route_reads_all_user_data():
-    assert False
+from unittest.mock import patch
+import pytest
+from flask import url_for
+
+
+class TestNotifyRoute:
+    @pytest.mark.unit
+    @patch("app.main.routes.ExportFactory", autospec=True)
+    def test_when_route_passed_form_creates_exporter(self, patched_factory, client):
+        patch("app.main.routes.celery.group").start()
+        client.set_cookie(server_name="localhost", key="data-folder", value="test")
+        with patch.object(patched_factory, "create_exporter") as patched_creator:
+            client.post(url_for("main.notify_participants"), data={"service": "notify"})
+            patched_creator.assert_called_with("notify")
+
+    def test_notify_route_reads_all_user_data(self):
+        assert False

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -43,3 +43,11 @@ def test_find_best_outcome(base_mentor, base_mentee):
         [base_mentee],
         0,
     )
+
+
+def test_notification_task():
+    """
+    This test checks whether a task, when given an `ExporterProtocol` implementing object and the necessary parameters,
+    calls it appropriately
+    """
+    assert False

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -43,11 +43,3 @@ def test_find_best_outcome(base_mentor, base_mentee):
         [base_mentee],
         0,
     )
-
-
-def test_notification_task():
-    """
-    This test checks whether a task, when given an `ExporterProtocol` implementing object and the necessary parameters,
-    calls it appropriately
-    """
-    assert False


### PR DESCRIPTION
## [2.4.0] - 2022-06-26

### Added

- This change exposes a route that, on a `POST` request:
  - reads a cookie `task-id`, which is the folder where the output is stored
  - receives a form from the request, which has a `template-id`, a `reply-id`, a `service`, and an `api-key`
  - the `service` defaults to Notify, so for the moment that choice doesn't need to be coded into the system
  - it creates the appropriate client for the `service`, and then sends every participant, in both files in the
    output folder, the `template-id` email using each row in the file as the personalisation
  - the emails are handed off to Celery to take care of
  - this does not yet take account of any other templates: for example, templates where no matches have been made.
    These `template-id`s would need to be passed, somehow, from the frontend. Alternatively, a template could be
    designed that comprises big `if ...then` blocks

