### PR TITLE
Add Jekyll docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,49 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+*DS_Store
+rebuild.sh
+Gemfile.lock
+
+# Temporary folders
+tmp/
+temp/
+
+# dotenv environment variables file
+.env
+.env.test
+
+### Node ###
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Yarn Integrity file
+.yarn-integrity

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.mentoring.service.civilservice.lgbt

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,122 @@
+### This file acts as the global config across the website.
+### Any variables in this file can be accessed in other files using
+###    `{{ site.variable }}`
+
+######################
+# Site configuration #
+######################
+# This title will display across the website
+title: "Mentor matcher"
+# This description is predominantly for Search Engine Optimisation
+description: "Documentation for the Civil Service LGBT+ mentor matcher software"
+# Instead of "author", have the organisation name as the default
+author: "Civil Service LGBT+ Network"
+organisation: "Civil Service LGBT+ Network"
+email: "info@civilservice.lgbt"
+
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://docs.mentoring.service.civilservice.lgbt"
+
+###################
+# Header settings #
+###################
+header-menu--links--hidden: true
+
+###################
+# Footer settings #
+###################
+# This text will be displayed at the bottom of the website.
+footer--production-notice: "Website created by <a href='https://www.twitter.com/jonodrew' title='Jonathan’s Twitter (Opens in new window)' target='_blank' rel='noopener noreferrer'>Jonathan Kerr</a> and <a href='//www.johnpe.art' title='Visit John Peart’s website (Opens in new window)' target='_blank' rel='noopener noreferrer'>John Peart</a>."
+footer--copyright-notice: "All content is released under the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' title='Read more about the Open Government License. (Opens in new window)' target='_blank'>Open Government License</a> unless otherwise stated. Please attribute our work."
+
+###############
+# Asset paths #
+###############
+# General paths
+image-path: "/assets/images"
+css-path: "/assets/styles"
+js-path: "/assets/scripts"
+
+# Favicons and social graph
+social-media-image: "/assets/images/site/social-media.png"
+favicon: "/favicon.ico"
+favicon-svg: "/assets/images/site/favicon.svg"
+favicon-pinned-svg: "/assets/images/site/favicon-pinned-svg.svg"
+favicon-large-png: "/assets/images/site/favicon-large-png.png"
+theme-colour: "#e6007e"
+
+
+
+##################################
+# Analytics and domain ownership #
+##################################
+# Google settings
+google-site-verification: "RA-YBjxyRYVSuSFAYLKkufs6gjme6kMcihoB2KgKrTA"
+
+##############
+# Newsletter #
+##############
+# Mailchimp
+unsubscribe-form: "https://us17.admin.mailchimp.com/lists/designer/?id=118945"
+
+###############
+# Collections #
+###############
+#This is the default permalink for the "_posts" folder.
+permalink: /:year/:month/:day/:title:output_ext
+
+collections:
+  docs:
+    output: true
+    permalink: /:path/
+    defaults:
+      values:
+        layout: "post"
+        
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "docs"
+      loop: docs
+      meta-info: false
+      caption: "Documentation"
+  - scope:
+      type: "docs"
+    values:
+      layout: "docs"
+      meta-info: false
+      caption: "Documentation"
+
+##################
+# Build settings #
+##################
+remote_theme: civilservicelgbt/magenta
+permalink: pretty
+markdown: kramdown
+highlighter: rouge
+sass:
+  sass_dir: _sass
+
+plugins:
+- jekyll-remote-theme
+- jekyll-sitemap
+- jekyll-feed
+- jekyll-redirect-from
+
+
+# Exclude from processing.
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
+# exclude:
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/
+
+
+
+# Date - 2021-07-23

--- a/docs/_docs/second-test-document.md
+++ b/docs/_docs/second-test-document.md
@@ -1,0 +1,7 @@
+---
+title: Another document
+excerpt: "This is a short, descriptive excerpt."
+category: "second category"
+---
+
+This is a test document.

--- a/docs/_docs/test-document.md
+++ b/docs/_docs/test-document.md
@@ -1,0 +1,7 @@
+---
+title: Test document
+excerpt: "This is a short, descriptive excerpt."
+category: "test category"
+---
+
+This is a test document.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+---
+title: Mentor matcher
+excerpt: This documentation is for the Civil Service LGBT+ mentoring programme mentor matcher software package.
+---
+


### PR DESCRIPTION
This pull request sets up the basics for issue #108 and adds Jekyll / Github Pages for documentation.