### PR TITLE
#109 implement notify

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.0
+current_version = 2.5.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Users can now edit the weightings, but only for specific attributes, and for the pre-existing calculation
 
+[2.5.0]
+
+### Added
+This release adds the notification workflow, using GOV.UK Notify. Getting from the "matching" to the "notification"
+workflow is a little rough, and we expect that to be fixed up in the next patch release.
+
+The user interface has once again been designed and implemented by @johnpeart.
+
+We've also added some really nice docs, and so they're being added to this release too - two for the price of one,
+you lucky people. As ever the entire system can be brought up with `docker-compose up`. Check out the docs on
+`localhost:4000`. Documentation is so important for an open-source system like ours, so additions to that are just
+as welcome as code changes.
+
 ## [2.4.0] - 2022-06-26
 
 ### Added

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,8 @@
 import configparser
 import os
+import secrets
 
 from flask import Flask
-import secrets
 
 from app.config import Config
 from app.tasks import make_celery
@@ -19,9 +19,11 @@ def create_app(configuration=Config):
 
     from app.main import main_bp
     from app.auth import auth_bp
+    from app.notify import notify_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(notify_bp)
 
     app.secret_key = secrets.token_urlsafe(48)
 

--- a/app/classes.py
+++ b/app/classes.py
@@ -64,6 +64,7 @@ class CSPerson(Person):
 
     def to_dict_for_output(self, depth=1) -> dict:
         return {
+            "type": self.class_name(),
             "first name": self.first_name,
             "last name": self.last_name,
             "email address": self.email,

--- a/app/export.py
+++ b/app/export.py
@@ -27,8 +27,8 @@ class NotifyClient(NotificationsAPIClient):
         )
 
     def _get_template(self, person: dict[str, str]) -> str:
-        number_matches = int(person.get("number of matches"))
-        person_type = person.get("type")
+        number_matches = int(person["number of matches"])
+        person_type = person["type"]
         if person_type == "csmentor":
             if number_matches > 0:
                 return self.templates["mentor-matches"]

--- a/app/export.py
+++ b/app/export.py
@@ -1,19 +1,47 @@
+import logging
+from typing import TypedDict
+
 from notifications_python_client import NotificationsAPIClient
+
+
+class ParticipantDict(TypedDict):
+    pass
 
 
 class NotifyClient(NotificationsAPIClient):
     def __init__(self, **kwargs):
-        super(NotifyClient, self).__init__(kwargs.get("api-key"))
-        self.template_id: str = kwargs.get("template-id")
-        self.email_reply_to_id: str = kwargs.get("reply-id")
+        super(NotifyClient, self).__init__(api_key=kwargs.get("api_key"))
+        template_prefix = "template-id-field-"
+        logging.log(logging.INFO, kwargs)
+        self.templates: dict[str, str] = {
+            key[len(template_prefix) :]: value
+            for key, value in kwargs.items()
+            if key.startswith(template_prefix)
+        }
+        self.email_reply_to_id: str = kwargs.get("reply-id", None)
 
     def send_email(self, recipient: str, **personalisation_data):
         self.send_email_notification(
             email_address=recipient,
-            template_id=self.template_id,
+            template_id=self._get_template(personalisation_data),
             personalisation=personalisation_data,
             email_reply_to_id=self.email_reply_to_id,
         )
+
+    def _get_template(self, person: dict[str, str]) -> str:
+        number_matches = int(person.get("number of matches"))
+        person_type = person.get("type")
+        logging.log(logging.INFO, self.templates)
+        if person_type == "csmentor":
+            if number_matches > 0:
+                return self.templates["mentor-matches"]
+            else:
+                return self.templates["mentors-no-matches"]
+        else:
+            if number_matches > 0:
+                return self.templates["mentees-matches"]
+            else:
+                return self.templates["mentees-no-matches"]
 
 
 class ExportFactory:

--- a/app/export.py
+++ b/app/export.py
@@ -1,4 +1,3 @@
-import logging
 from typing import TypedDict
 
 from notifications_python_client import NotificationsAPIClient
@@ -12,7 +11,6 @@ class NotifyClient(NotificationsAPIClient):
     def __init__(self, **kwargs):
         super(NotifyClient, self).__init__(api_key=kwargs.get("api_key"))
         template_prefix = "template-id-field-"
-        logging.log(logging.INFO, kwargs)
         self.templates: dict[str, str] = {
             key[len(template_prefix) :]: value
             for key, value in kwargs.items()
@@ -31,7 +29,6 @@ class NotifyClient(NotificationsAPIClient):
     def _get_template(self, person: dict[str, str]) -> str:
         number_matches = int(person.get("number of matches"))
         person_type = person.get("type")
-        logging.log(logging.INFO, self.templates)
         if person_type == "csmentor":
             if number_matches > 0:
                 return self.templates["mentor-matches"]

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -199,6 +199,4 @@ def base_rules() -> list[rl.Rule]:
 
 
 def get_data_folder_path(app_instance: flask.Flask, folder_name: str) -> pathlib.Path:
-    return pathlib.Path(
-        os.path.join(app_instance.config["UPLOAD_FOLDER"].strpath, folder_name)
-    )
+    return pathlib.Path(os.path.join(app_instance.config["UPLOAD_FOLDER"], folder_name))

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -258,50 +258,69 @@ def finished():
     return render_template("done.html")
 
 
-@main_bp.route("/notify-participants", methods=["GET", "POST"])
-def notify_participants():
-    if request.method == "GET":
-        return render_template("notify-settings.html")
-    else:
-        form = request.form.to_dict()
-        service = form.pop("service", "notify")
-        data_folder = request.cookies.get("task-id", "")
-        if (data_path := get_data_folder_path(current_app, data_folder)).exists():
-            try:
-                exporter = ExportFactory.create_exporter(service, **form)
-            except AssertionError:
-                raise werkzeug.exceptions.BadRequest(
-                    "The API key you have provided is not recognised"
-                )
-            for string in ("csmentors-list.csv", "csmentees-list.csv"):
-                with open(
-                    pathlib.Path(os.path.join(data_path, string))
-                ) as participant_csv:
-                    reader = csv.DictReader(participant_csv)
-                    celery.group(
-                        send_notification.si(exporter, participant)
-                        for participant in reader
-                    ).apply_async()
-            return Response(status=200)
-        else:
-            abort(404, "That data doesn't exist")
-
-
 @main_bp.route("/notify-settings/before-you-start", methods=["GET"])
 def notify_settings_before_you_start():
     return render_template("notify-settings/notify-settings-intro.html")
 
 
-@main_bp.route("/notify-settings/api-key", methods=["GET"])
-def notify_settings_api_key():
-    return render_template("notify-settings/notify-settings--api-key.html")
-
-
-@main_bp.route("/notify-settings/reply-to", methods=["GET"])
-def notify_settings_reply_id():
-    return render_template("notify-settings/notify-settings--reply-to.html")
-
-
 @main_bp.route("/notify-settings/template-ids", methods=["GET"])
 def notify_settings_template_id():
     return render_template("notify-settings/notify-settings--template-ids.html")
+
+
+@main_bp.route("/notify-settings/reply-to", methods=["GET", "POST"])
+def notify_settings_reply_id():
+    response = make_response(
+        render_template("notify-settings/notify-settings--reply-to.html")
+    )
+    if request.method == "POST":
+        for name, value in request.form.items():
+            response.set_cookie(
+                name, value, expires=datetime.datetime.utcnow() + timedelta(minutes=15)
+            )
+    return response
+
+
+@main_bp.route("/notify-settings/api-key", methods=["GET", "POST"])
+def notify_settings_api_key():
+    response = make_response(
+        render_template("notify-settings/notify-settings--api-key.html")
+    )
+    if request.method == "POST":
+        for name, value in request.form.items():
+            response.set_cookie(
+                name, value, expires=datetime.datetime.utcnow() + timedelta(minutes=15)
+            )
+    return response
+
+
+@main_bp.route("/notify-settings/done", methods=["POST"])
+def notify_settings_done():
+    queue_emails()
+    return redirect(url_for("main.index"))
+
+
+def queue_emails():
+    service = request.cookies.get("service", "notify")
+    data_folder = request.cookies["task-id"]
+    if (data_path := get_data_folder_path(current_app, data_folder)).exists():
+        current_app.logger.debug(request.cookies)
+        try:
+            exporter = ExportFactory.create_exporter(
+                service, api_key=request.form.get("api-key-field"), **request.cookies
+            )
+        except AssertionError as e:
+            current_app.logger.info(e)
+            raise werkzeug.exceptions.BadRequest(
+                "The API key you have provided is not recognised"
+            )
+        for string in ("csmentors-list.csv", "csmentees-list.csv"):
+            with open(pathlib.Path(os.path.join(data_path, string))) as participant_csv:
+                reader = csv.DictReader(participant_csv)
+                batch = celery.group(
+                    send_notification.si(exporter, participant)
+                    for participant in reader
+                ).apply_async()
+        return Response(response=batch.id, status=201)
+    else:
+        abort(404, "That data doesn't exist")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -303,7 +303,6 @@ def queue_emails():
     service = request.cookies.get("service", "notify")
     data_folder = request.cookies["task-id"]
     if (data_path := get_data_folder_path(current_app, data_folder)).exists():
-        current_app.logger.debug(request.cookies)
         try:
             exporter = ExportFactory.create_exporter(
                 service, api_key=request.form.get("api-key-field"), **request.cookies

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -276,7 +276,8 @@ def notify_settings_reply_id():
     if request.method == "POST":
         for name, value in request.form.items():
             response.set_cookie(
-                name, value, expires=datetime.datetime.utcnow() + timedelta(minutes=15)
+                name,
+                value,
             )
     return response
 
@@ -288,9 +289,7 @@ def notify_settings_api_key():
     )
     if request.method == "POST":
         for name, value in request.form.items():
-            response.set_cookie(
-                name, value, expires=datetime.datetime.utcnow() + timedelta(minutes=15)
-            )
+            response.set_cookie(name, value)
     return response
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,3 @@
-import csv
 import datetime
 import json
 import os.path
@@ -6,8 +5,6 @@ import pathlib
 import shutil
 from datetime import timedelta
 
-import celery
-import werkzeug.exceptions
 from flask import (
     make_response,
     render_template,
@@ -18,21 +15,18 @@ from flask import (
     send_from_directory,
     after_this_request,
     Response,
-    abort,
 )
 from matching.process import create_participant_list_from_path, create_mailing_list
 from werkzeug.utils import secure_filename, redirect
 
 from app.classes import CSMentor, CSMentee
-from app.export import ExportFactory
 from app.extensions import celery_app
-from app.helpers import valid_files, random_string, get_data_folder_path
+from app.helpers import valid_files, random_string
 from app.main import main_bp
 from app.tasks.helpers import most_mentees_with_at_least_one_mentor
 from app.tasks.tasks import (
     async_process_data,
     delete_mailing_lists_after_period,
-    send_notification,
 )
 
 
@@ -256,69 +250,3 @@ def process():
 @main_bp.route("/finished", methods=["GET"])
 def finished():
     return render_template("done.html")
-
-
-@main_bp.route("/notify-settings/before-you-start", methods=["GET"])
-def notify_settings_before_you_start():
-    return render_template("notify-settings/notify-settings-intro.html")
-
-
-@main_bp.route("/notify-settings/template-ids", methods=["GET"])
-def notify_settings_template_id():
-    return render_template("notify-settings/notify-settings--template-ids.html")
-
-
-@main_bp.route("/notify-settings/reply-to", methods=["GET", "POST"])
-def notify_settings_reply_id():
-    response = make_response(
-        render_template("notify-settings/notify-settings--reply-to.html")
-    )
-    if request.method == "POST":
-        for name, value in request.form.items():
-            response.set_cookie(
-                name,
-                value,
-            )
-    return response
-
-
-@main_bp.route("/notify-settings/api-key", methods=["GET", "POST"])
-def notify_settings_api_key():
-    response = make_response(
-        render_template("notify-settings/notify-settings--api-key.html")
-    )
-    if request.method == "POST":
-        for name, value in request.form.items():
-            response.set_cookie(name, value)
-    return response
-
-
-@main_bp.route("/notify-settings/done", methods=["POST"])
-def notify_settings_done():
-    queue_emails()
-    return redirect(url_for("main.index"))
-
-
-def queue_emails():
-    service = request.cookies.get("service", "notify")
-    data_folder = request.cookies["task-id"]
-    if (data_path := get_data_folder_path(current_app, data_folder)).exists():
-        try:
-            exporter = ExportFactory.create_exporter(
-                service, api_key=request.form.get("api-key-field"), **request.cookies
-            )
-        except AssertionError as e:
-            current_app.logger.info(e)
-            raise werkzeug.exceptions.BadRequest(
-                "The API key you have provided is not recognised"
-            )
-        for string in ("csmentors-list.csv", "csmentees-list.csv"):
-            with open(pathlib.Path(os.path.join(data_path, string))) as participant_csv:
-                reader = csv.DictReader(participant_csv)
-                batch = celery.group(
-                    send_notification.si(exporter, participant)
-                    for participant in reader
-                ).apply_async()
-        return Response(response=batch.id, status=201)
-    else:
-        abort(404, "That data doesn't exist")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -287,6 +287,11 @@ def notify_participants():
             abort(404, "That data doesn't exist")
 
 
+@main_bp.route("/notify-settings/before-you-start", methods=["GET"])
+def notify_settings_before_you_start():
+    return render_template("notify-settings/notify-settings-intro.html")
+
+
 @main_bp.route("/notify-settings/api-key", methods=["GET"])
 def notify_settings_api_key():
     return render_template("notify-settings/notify-settings--api-key.html")

--- a/app/notify/__init__.py
+++ b/app/notify/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+notify_bp = Blueprint("notify", __name__, url_prefix="/notify")
+
+from app.notify import routes  # noqa: E402,F401

--- a/app/notify/routes.py
+++ b/app/notify/routes.py
@@ -21,17 +21,17 @@ from app.notify import notify_bp
 from app.tasks.tasks import send_notification
 
 
-@notify_bp.route("/notify-settings/before-you-start", methods=["GET"])
+@notify_bp.route("/before-you-start", methods=["GET"])
 def notify_settings_before_you_start():
     return render_template("notify-settings/notify-settings-intro.html")
 
 
-@notify_bp.route("/notify-settings/template-ids", methods=["GET"])
+@notify_bp.route("/template-ids", methods=["GET"])
 def notify_settings_template_id():
     return render_template("notify-settings/notify-settings--template-ids.html")
 
 
-@notify_bp.route("/notify-settings/reply-to", methods=["GET", "POST"])
+@notify_bp.route("/reply-to", methods=["GET", "POST"])
 def notify_settings_reply_id():
     response = make_response(
         render_template("notify-settings/notify-settings--reply-to.html")
@@ -45,7 +45,7 @@ def notify_settings_reply_id():
     return response
 
 
-@notify_bp.route("/notify-settings/api-key", methods=["GET", "POST"])
+@notify_bp.route("/api-key", methods=["GET", "POST"])
 def notify_settings_api_key():
     response = make_response(
         render_template("notify-settings/notify-settings--api-key.html")
@@ -56,7 +56,7 @@ def notify_settings_api_key():
     return response
 
 
-@notify_bp.route("/notify-settings/done", methods=["POST"])
+@notify_bp.route("/done", methods=["POST"])
 def notify_settings_done():
     queue_emails()
     return redirect(url_for("main.index"))

--- a/app/notify/routes.py
+++ b/app/notify/routes.py
@@ -1,0 +1,87 @@
+import csv
+import os
+import pathlib
+
+import celery
+import werkzeug as werkzeug
+from flask import (
+    render_template,
+    request,
+    redirect,
+    make_response,
+    Response,
+    current_app,
+    url_for,
+    abort,
+)
+
+from app.export import ExportFactory
+from app.helpers import get_data_folder_path
+from app.notify import notify_bp
+from app.tasks.tasks import send_notification
+
+
+@notify_bp.route("/notify-settings/before-you-start", methods=["GET"])
+def notify_settings_before_you_start():
+    return render_template("notify-settings/notify-settings-intro.html")
+
+
+@notify_bp.route("/notify-settings/template-ids", methods=["GET"])
+def notify_settings_template_id():
+    return render_template("notify-settings/notify-settings--template-ids.html")
+
+
+@notify_bp.route("/notify-settings/reply-to", methods=["GET", "POST"])
+def notify_settings_reply_id():
+    response = make_response(
+        render_template("notify-settings/notify-settings--reply-to.html")
+    )
+    if request.method == "POST":
+        for name, value in request.form.items():
+            response.set_cookie(
+                name,
+                value,
+            )
+    return response
+
+
+@notify_bp.route("/notify-settings/api-key", methods=["GET", "POST"])
+def notify_settings_api_key():
+    response = make_response(
+        render_template("notify-settings/notify-settings--api-key.html")
+    )
+    if request.method == "POST":
+        for name, value in request.form.items():
+            response.set_cookie(name, value)
+    return response
+
+
+@notify_bp.route("/notify-settings/done", methods=["POST"])
+def notify_settings_done():
+    queue_emails()
+    return redirect(url_for("main.index"))
+
+
+def queue_emails():
+    service = request.cookies.get("service", "notify")
+    data_folder = request.cookies["task-id"]
+    if (data_path := get_data_folder_path(current_app, data_folder)).exists():
+        try:
+            exporter = ExportFactory.create_exporter(
+                service, api_key=request.form.get("api-key-field"), **request.cookies
+            )
+        except AssertionError as e:
+            current_app.logger.info(e)
+            raise werkzeug.exceptions.BadRequest(
+                "The API key you have provided is not recognised"
+            )
+        for string in ("csmentors-list.csv", "csmentees-list.csv"):
+            with open(pathlib.Path(os.path.join(data_path, string))) as participant_csv:
+                reader = csv.DictReader(participant_csv)
+                batch = celery.group(
+                    send_notification.si(exporter, participant)
+                    for participant in reader
+                ).apply_async()
+        return Response(response=batch.id, status=201)
+    else:
+        abort(404, "That data doesn't exist")

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -34,6 +34,8 @@ function getStatus(taskID) {
 
       matching.innerHTML = '<blockquote class="warning-text"><h2 class="heading-sm">Matching is complete</h2><p>Mentors and mentees have been matched. You will be redirected in 3 seconds.</p></blockquote>';
       setTimeout(function() {
+        document.cookie="task-id=" + res.task_id
+
         window.location.replace(downloadURL)
       }, 3000);
     }

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -70,4 +70,6 @@ def delete_mailing_lists_after_period(self, task_id: str):
 
 @celery_app.task
 def send_notification(exporter: Exporter, participant_data: dict[str, str]):
-    return exporter.send_email(participant_data.get("email", ""), **participant_data)
+    return exporter.send_email(
+        participant_data.get("email address", ""), **participant_data
+    )

--- a/app/templates/notify-settings/notify-settings--api-key.html
+++ b/app/templates/notify-settings/notify-settings--api-key.html
@@ -5,7 +5,7 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="options">
 
-    <form method=post enctype=multipart/form-data action="">
+    <form method=post enctype=multipart/form-data action="{{ url_for("main.notify_settings_done") }}">
       {% if error_message %}
       <blockquote class="error warning-text">
         <p><strong>An error has occurred</strong></p>

--- a/app/templates/notify-settings/notify-settings--api-key.html
+++ b/app/templates/notify-settings/notify-settings--api-key.html
@@ -5,7 +5,7 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="options">
 
-    <form method=post enctype=multipart/form-data action="{{ url_for("main.notify_settings_done") }}">
+    <form method=post enctype=multipart/form-data action="{{ url_for("notify.notify_settings_done") }}">
       {% if error_message %}
       <blockquote class="error warning-text">
         <p><strong>An error has occurred</strong></p>

--- a/app/templates/notify-settings/notify-settings--reply-to.html
+++ b/app/templates/notify-settings/notify-settings--reply-to.html
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="options">
 
-    <form method=post enctype=multipart/form-data action="{{ url_for("main.notify_settings_api_key") }}">
+    <form method=post enctype=multipart/form-data action="{{ url_for("notify.notify_settings_api_key") }}">
       {% if error_message %}
       <blockquote class="error warning-text">
         <p><strong>An error has occurred</strong></p>

--- a/app/templates/notify-settings/notify-settings--reply-to.html
+++ b/app/templates/notify-settings/notify-settings--reply-to.html
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="options">
 
-    <form method=post enctype=multipart/form-data action="">
+    <form method=post enctype=multipart/form-data action="{{ url_for("main.notify_settings_api_key") }}">
       {% if error_message %}
       <blockquote class="error warning-text">
         <p><strong>An error has occurred</strong></p>
@@ -20,16 +20,16 @@
 
           <!-- Reply ID isn't necessary if the Notify account only has 1 reply-to email address set up -->
           <p id="fieldset-notify--hint" class="hint">Emails sent from GOV.UK Notify must have a “reply-to” email address.</p>
-          
+
           <p id="fieldset-notify--hint" class="hint">If you'd like users to reply to an email address that is different to the default, you'll need to add it on the GOV.UK Notify website. Once you've done that, copy and paste its reply-to ID key into the text field below.</p>
-                    
+
           <hr>
-          
+
           <blockquote class="warning-text">
             <p><strong>Your reply-to ID key is not your email address</strong></p>
             <p>Reply-to ID keys are strings of numbers and letters, separated by hyphens. You can copy them from the GOV.UK Notify website.</p>
           </blockquote>
-          
+
           <label class="input-label label-md" for="reply-id-field">
             Reply-to ID key
           </label>

--- a/app/templates/notify-settings/notify-settings--template-ids.html
+++ b/app/templates/notify-settings/notify-settings--template-ids.html
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="options">
 
-    <form method=post enctype=multipart/form-data action="">
+    <form method=post enctype=multipart/form-data action="{{ url_for("main.notify_settings_reply_id") }}">
       {% if error_message %}
       <blockquote class="error warning-text">
         <p><strong>An error has occurred</strong></p>

--- a/app/templates/notify-settings/notify-settings--template-ids.html
+++ b/app/templates/notify-settings/notify-settings--template-ids.html
@@ -4,7 +4,7 @@
 <div class="grid-row">
   <div class="grid-column-two-thirds" id="options">
 
-    <form method=post enctype=multipart/form-data action="{{ url_for("main.notify_settings_reply_id") }}">
+    <form method=post enctype=multipart/form-data action="{{ url_for("notify.notify_settings_reply_id") }}">
       {% if error_message %}
       <blockquote class="error warning-text">
         <p><strong>An error has occurred</strong></p>

--- a/app/templates/notify-settings/notify-settings-intro.html
+++ b/app/templates/notify-settings/notify-settings-intro.html
@@ -1,0 +1,21 @@
+{% extends 'notify-settings/base-notify-settings.html' %}
+
+{%  block content %}
+<div class="grid-row">
+  <div class="grid-column-two-thirds">
+    <div class="page--content">
+    <h2 class="heading-md">Before you start</h2>
+    <ol>
+        <li><strong>You must have a Notify API key.</strong> You can <a href="https://www.notifications.service.gov.uk/">sign up for one on the service's homepage</a>.
+        <li><strong>You must have set up at least two templates in Notify</strong>. There should be one for mentors, and one for mentees</li>
+    </ol>
+        <p>If you haven't come here from the mentor-match service, we won't have access to your files. Please go to the
+            Notify service and upload your spreadsheet there</p>
+    <hr>
+    <div class="button-group">
+      <a href="{{ url_for("main.notify_settings_template_id") }}" class="button button--action">Start now</a>
+    </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/notify-settings/notify-settings-intro.html
+++ b/app/templates/notify-settings/notify-settings-intro.html
@@ -13,7 +13,7 @@
             Notify service and upload your spreadsheet there</p>
     <hr>
     <div class="button-group">
-      <a href="{{ url_for("main.notify_settings_template_id") }}" class="button button--action">Start now</a>
+      <a href="{{ url_for("notify.notify_settings_template_id") }}" class="button button--action">Start now</a>
     </div>
     </div>
   </div>

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="mentor-match",
-    version="2.4.0",
+    version="2.5.0",
     description="A web interface for the mentor-match-package",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -50,6 +50,7 @@ def test_matches_and_rules(base_mentor, base_mentee):
 def test_export(base_mentor, base_mentee, base_mentor_data):
     base_mentor.connections.extend([base_mentee, base_mentee])
     assert base_mentor.to_dict_for_output() == {
+        "type": "csmentor",
         "both mentor and mentee": "no",
         "email address": "test@data.com",
         "first name": "Test",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -9,9 +9,7 @@ from app.export import NotifyClient, ExportFactory
         [
             "notify",
             {
-                "api-key": "".join(str(_) for _ in range(100)),
-                "template-id": "12345",
-                "reply-id": "reply-to-me",
+                "api_key": "".join(str(_) for _ in range(100)),
             },
             NotifyClient,
         ],
@@ -21,6 +19,39 @@ def test_export_factory_create_clients_correctly(
     service_name, form_data, expected_client
 ):
     assert (
-        ExportFactory.create_exporter(service_name, **form_data).__dict__
-        == expected_client(**form_data).__dict__
+        type(ExportFactory.create_exporter(service_name, **form_data))
+        == expected_client
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ["client", "form_data", "attributes"],
+    [
+        (
+            "notify",
+            {
+                "api_key": "".join(str(_) for _ in range(100)),
+                "template-id-field-mentees-matches": "paired-mentees",
+                "template-id-field-mentees-no-matches": "solo-mentees",
+                "template-id-field-mentors-matches": "paired-mentors",
+                "template-id-field-mentors-no-matches": "solo-mentors",
+                "reply-id": "reply-to-me",
+            },
+            {
+                "api_key": "".join(str(_) for _ in range(100))[-36:],
+                "templates": {
+                    "mentees-matches": "paired-mentees",
+                    "mentees-no-matches": "solo-mentees",
+                    "mentors-matches": "paired-mentors",
+                    "mentors-no-matches": "solo-mentors",
+                },
+                "email_reply_to_id": "reply-to-me",
+            },
+        )
+    ],
+)
+def test_client_has_correct_attributes(client, form_data, attributes):
+    c = ExportFactory.create_exporter(client, **form_data)
+    for key, value in attributes.items():
+        assert getattr(c, key) == value

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,6 +95,7 @@ class TestIntegration:
         ) as csv_file:
             reader = csv.DictReader(csv_file)
             assert list(next(reader).keys()) == [
+                "type",
                 "first name",
                 "last name",
                 "email address",

--- a/tests/test_notify_client.py
+++ b/tests/test_notify_client.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.export import NotifyClient
+from unittest.mock import Mock
+
+
+class TestNotifyClient:
+    @pytest.mark.unit
+    def test_send_email(self):
+        client = NotifyClient(
+            api_key="".join(str(_) for _ in range(50)),
+            **{
+                "template-id-field-mentees-matches": "paired-mentees",
+                "template-id-field-mentees-no-matches": "solo-mentees",
+                "template-id-field-mentors-matches": "paired-mentors",
+                "template-id-field-mentors-no-matches": "solo-mentors",
+            }
+        )
+
+        client.send_email_notification = Mock()
+        client.send_email(
+            "joebloggs@test.com", **{"type": "csmentor", "number of matches": "0"}
+        )
+        client.send_email_notification.assert_called_once_with(
+            email_address="joebloggs@test.com",
+            template_id="solo-mentors",
+            personalisation={"type": "csmentor", "number of matches": "0"},
+            email_reply_to_id=None,
+        )

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -7,7 +7,7 @@ from flask import url_for
 
 @pytest.fixture
 def notify_client(client):
-    client.set_cookie(server_name="localhost", key="task-id", value="data")
+    client.set_cookie(server_name="localhost", key="task-id", value="")
     yield client
 
 
@@ -28,28 +28,28 @@ class TestNotifyRoute:
     @pytest.mark.unit
     @patch("app.main.routes.ExportFactory", autospec=True)
     def test_when_route_passed_form_creates_exporter(
-        self, patched_factory, client, patch_open_file
+        self, patched_factory, notify_client, patch_open_file
     ):
-        with patch("app.main.routes.celery.group"):
-            with patch.object(patched_factory, "create_exporter") as patched_creator:
-                client.post(
-                    url_for("main.notify_participants"), data={"service": "notify"}
-                )
-                patched_creator.assert_called_with("notify")
+        with patch("app.main.routes.celery.group"), patch.object(
+            patched_factory, "create_exporter"
+        ) as patched_creator:
+            notify_client.post(url_for("main.notify_settings_done"))
+            assert (
+                "notify" in patched_creator.call_args_list[0].args
+            )  # patched_creator.assert_called_with("notify")
 
     @pytest.mark.unit
     def test_notify_route_reads_all_user_data(
-        self, patch_open_file, test_data_path, client, patch_csv_reader
+        self, patch_open_file, test_data_path, notify_client, patch_csv_reader
     ):
         with patch(
             "app.main.routes.celery.group", autospec=True
         ) as patched_celery_group:
             with patch("app.main.routes.send_notification.si") as patched_notification:
-                client.post(
-                    url_for("main.notify_participants"),
+                notify_client.post(
+                    url_for("main.notify_settings_done"),
                     data={
-                        "service": "notify",
-                        "api-key": "".join(str(_) for _ in range(100)),
+                        "api-key-field": "".join(str(_) for _ in range(100)),
                     },
                 )
                 assert patched_celery_group.call_count == 2
@@ -62,22 +62,21 @@ class TestNotifyRoute:
 
     @pytest.mark.unit
     def test_notify_route_raises_404_if_no_data(self, notify_client):
+        notify_client.set_cookie(server_name="localhost", key="task-id", value="data")
         response = notify_client.post(
-            url_for("main.notify_participants"),
+            url_for("main.notify_settings_done"),
             data={
-                "service": "notify",
-                "api-key": "".join(str(_) for _ in range(100)),
+                "api-key-field": "".join(str(_) for _ in range(100)),
             },
         )
         assert response.status_code == 404
 
     @pytest.mark.unit
-    def test_route_raises_error_if_bad_api_key(self, client):
-        response = client.post(
-            url_for("main.notify_participants"),
+    def test_route_raises_error_if_bad_api_key(self, notify_client):
+        response = notify_client.post(
+            url_for("main.notify_settings_done"),
             data={
-                "service": "notify",
-                "api-key": "".join(str(_) for _ in range(10)),
+                "api-key-field": "".join(str(_) for _ in range(10)),
             },
         )
         assert response.status_code == 400

--- a/tests/test_notify_route.py
+++ b/tests/test_notify_route.py
@@ -14,26 +14,28 @@ def notify_client(client):
 @pytest.fixture
 def patch_open_file():
     data = mock.mock_open(read_data="first,second,third")
-    with patch(target="app.main.routes.open", new=data):
+    with patch(target="app.notify.routes.open", new=data):
         yield
 
 
 @pytest.fixture
 def patch_csv_reader():
-    with patch("app.main.routes.csv.DictReader", return_value=({} for _ in range(10))):
+    with patch(
+        "app.notify.routes.csv.DictReader", return_value=({} for _ in range(10))
+    ):
         yield
 
 
 class TestNotifyRoute:
     @pytest.mark.unit
-    @patch("app.main.routes.ExportFactory", autospec=True)
+    @patch("app.notify.routes.ExportFactory", autospec=True)
     def test_when_route_passed_form_creates_exporter(
         self, patched_factory, notify_client, patch_open_file
     ):
-        with patch("app.main.routes.celery.group"), patch.object(
+        with patch("app.notify.routes.celery.group"), patch.object(
             patched_factory, "create_exporter"
         ) as patched_creator:
-            notify_client.post(url_for("main.notify_settings_done"))
+            notify_client.post(url_for("notify.notify_settings_done"))
             assert (
                 "notify" in patched_creator.call_args_list[0].args
             )  # patched_creator.assert_called_with("notify")
@@ -43,11 +45,13 @@ class TestNotifyRoute:
         self, patch_open_file, test_data_path, notify_client, patch_csv_reader
     ):
         with patch(
-            "app.main.routes.celery.group", autospec=True
+            "app.notify.routes.celery.group", autospec=True
         ) as patched_celery_group:
-            with patch("app.main.routes.send_notification.si") as patched_notification:
+            with patch(
+                "app.notify.routes.send_notification.si"
+            ) as patched_notification:
                 notify_client.post(
-                    url_for("main.notify_settings_done"),
+                    url_for("notify.notify_settings_done"),
                     data={
                         "api-key-field": "".join(str(_) for _ in range(100)),
                     },
@@ -64,7 +68,7 @@ class TestNotifyRoute:
     def test_notify_route_raises_404_if_no_data(self, notify_client):
         notify_client.set_cookie(server_name="localhost", key="task-id", value="data")
         response = notify_client.post(
-            url_for("main.notify_settings_done"),
+            url_for("notify.notify_settings_done"),
             data={
                 "api-key-field": "".join(str(_) for _ in range(100)),
             },
@@ -74,7 +78,7 @@ class TestNotifyRoute:
     @pytest.mark.unit
     def test_route_raises_error_if_bad_api_key(self, notify_client):
         response = notify_client.post(
-            url_for("main.notify_settings_done"),
+            url_for("notify.notify_settings_done"),
             data={
                 "api-key-field": "".join(str(_) for _ in range(10)),
             },


### PR DESCRIPTION
Should fix #109 

This is a great big chunk of work, and it's still not quite finished. We need a neat way to tie together the matching workflow and this notifications workflow. Ideas welcome.

However, for now, you can test this by going through the matching workflow, and then going to `/notify-settings/before-you-start`. From there, follow the workflow through.

ONLY USE A TEST API KEY. This service is genuinely connected to the genuine internet and will genuinely email a whole bunch of people if you tell it to.

So don't!

Okay, that's the lecture over. So @johnpeart , what do you think? I know there's more to do, but let's get it integrated now and tidy up later.