### PR TITLE
Iac deployment with Terraform and AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,43 @@
 .vscode/settings.json
 *.pyc
 /.python-version
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/iac/terraform/.terraform.lock.hcl
+++ b/iac/terraform/.terraform.lock.hcl
@@ -1,0 +1,81 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.28.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:TXCUuuaf2q54C43bxSNiF9g+cxTr8zqEZem0pW15cjE=",
+    "zh:1d4806e50971d2cd565273cedf3206e38931677a6f546cf2b9fb140b52b80604",
+    "zh:3f076791002b8afa5ba2d2038f1e1db5956022327eb5242152723ed410ae4571",
+    "zh:40e5944a9df0d083dbd316bcc6ac9ceada5c00dab70c21897e62b68c4c936bc9",
+    "zh:68b78d0c1866aa0bcbbadb1cf51349c9af697f8789f5778b7e7e2912a9c4845d",
+    "zh:72d6e66136841c0e5ae264e03555cf59751ddae1b9784eafcb877c624332c70a",
+    "zh:902c8f89dc10d321b87c09270c27a31a42d4e74e4da1608e55b7f241cd010a62",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf54c9f55d420b4e1fe68db81a759c40b9f9747159dea3061212a1c9768dcdfd",
+    "zh:bfbe7e745c420a4ebd27ca35dfe5c2acc7cdd05092e1daf60f5ae29a1130d752",
+    "zh:d271a30b16f0861f020e423d120d1458cf1757e740e016ace22084c39dc13550",
+    "zh:f1e4672d1625fd1f1268d4b807cb90e28150d46fb2d0dd0836de65db29c8d5e6",
+    "zh:f5cee910b4db2da3c2a28dae9055cbca4273eb774c362bb7bb5bde04deff4557",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.2.3"
+  constraints = ">= 1.3.0"
+  hashes = [
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.3.2"
+  hashes = [
+    "h1:H5V+7iXol/EHB2+BUMzGlpIiCOdV74H8YjzCxnSAWcg=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.8.0"
+  constraints = ">= 0.7.0"
+  hashes = [
+    "h1:sT/5WKFSUol4n0ShXDFMlv2ufVHKMk4SLBUDV1ffsX0=",
+    "zh:02eabf4c6239c5b950cc99bb214b2c55e8259d911bcb1a1b26988a0227fe10d4",
+    "zh:05220f907b274347dec0ffa8383becc6a3640324bc5d60e2b938d5429ed81f5e",
+    "zh:14165bc5a859c9d617fda2cedaeec1b7a20f8590969faa24aa34c1fc273c23b9",
+    "zh:1abe696cbe17c070ac98745a357760827bc49ff8a6647b9e1a5cb52010edcbe0",
+    "zh:20ec0ad2dec862fb6412047f4855bbd79d1a2e18a149088b337805f9b3766974",
+    "zh:3d70d4836b35b4ec9477d49685f6773cc765aea679d19cbeeeb485e2185f620a",
+    "zh:4137272743250ac557dd8c2ba92c93aa21cf9c85edfa7fbe07a3a94c9e9783a7",
+    "zh:525304ba8fd0abcc1d767b47114b6dfaf74d2a0afe0eaa656a38e81cc2651313",
+    "zh:76241458be0613fabcf347068af9ed846f829ba4e683e10beca631be26312db2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:85f2b4caaf0485c5346a576a2c7a5b1e155b1b72f95f70bfbc80e233e6916622",
+    "zh:f93d3b0b6553f5a438312ff2b46025b67786f7b76b1ea833a4c72cb29edc1ad2",
+  ]
+}

--- a/iac/terraform/README.md
+++ b/iac/terraform/README.md
@@ -1,0 +1,18 @@
+Infrastructure as Code - Terraform for Mentor Match Deployment
+===============================================================
+
+Services used: 
+
+* AWS Elasticache
+* AWS App Runner
+* AWS Elastic Container Repositories (ECR)
+* AWS Elastic Container Services (ECS)
+* Route 53
+
+Using this code:
+---------------
+
+1. Create a Route53 Hosted Zone for your domain (not included in the terraform because reasons.)
+2. Create somewhere to host the docker images for `mentor-match-app` and `mentor-match-worker`.  I used AWS ECR, and VPC Endpoints for isolated subnets to be able to access them. If you were using Docker Hub, you'd want to change some stuff to host the application either in Public subnets, or Private with a NAT gateway. 
+3. Create a .tfvars file containing definitions for the variables `hosted_zone_id`, `application_image_uri` and `worker_image_uri`. 
+4. Run terraform to provision the infrastructure.

--- a/iac/terraform/apprunner.tf
+++ b/iac/terraform/apprunner.tf
@@ -1,0 +1,127 @@
+resource "aws_iam_role" "mmweb_build" {
+  name               = "mmweb-build"
+  assume_role_policy = <<EOF
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "build.apprunner.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+resource "aws_iam_role_policy_attachment" "mmweb_build" {
+  role       = aws_iam_role.mmweb_build.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
+
+}
+
+resource "aws_iam_policy" "exec_policy" {
+  name        = "duplicate-slr-policy"
+  description = "duplicates the service linked role policy"
+  policy      = data.aws_iam_policy_document.apprunner_exec_policy.json
+}
+
+resource "aws_iam_role" "mmweb_exec" {
+  name               = "mmweb-exec"
+  assume_role_policy = <<EOF
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "tasks.apprunner.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "mmweb_exec" {
+  role       = aws_iam_role.mmweb_exec.name
+  policy_arn = aws_iam_policy.exec_policy.arn
+}
+
+resource "aws_security_group" "apprunner" {
+  name        = "apprunner"
+  description = "Allow egress to redis"
+  vpc_id      = module.vpc.vpc_id
+
+  egress {
+    from_port       = aws_elasticache_cluster.redis.cache_nodes.0.port
+    to_port         = aws_elasticache_cluster.redis.cache_nodes.0.port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.allow_redis_from_vpc.id]
+
+  }
+
+  tags = {
+    Name        = "allow_apprunner_to_redis_in_vpc"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+
+resource "aws_apprunner_vpc_connector" "connector" {
+  vpc_connector_name = "mm-vpc-connector"
+  subnets            = module.vpc.intra_subnets
+  security_groups    = [aws_security_group.allow_redis_from_vpc.id]
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+
+resource "aws_apprunner_service" "mmweb" {
+  service_name = "mmweb"
+  instance_configuration {
+    cpu               = 1024
+    memory            = 2048
+    instance_role_arn = aws_iam_role.mmweb_exec.arn
+  }
+  source_configuration {
+    authentication_configuration {
+      access_role_arn = aws_iam_role.mmweb_build.arn
+    }
+    image_repository {
+      image_configuration {
+        port = "5000"
+        runtime_environment_variables = {
+          "FLASK_APP" = "app:create_app()"
+          "FLASK_ENV" = "development"
+          "REDIS_URL" = "redis://${aws_elasticache_cluster.redis.cache_nodes.0.address}:${aws_elasticache_cluster.redis.cache_nodes.0.port}/0"
+        }
+      }
+      image_identifier      = var.application_image_uri
+      image_repository_type = "ECR"
+    }
+    auto_deployments_enabled = false
+  }
+  network_configuration {
+    egress_configuration {
+      egress_type       = "VPC"
+      vpc_connector_arn = aws_apprunner_vpc_connector.connector.arn
+    }
+
+  }
+
+
+  tags = {
+    Name = "mmweb-apprunner-service"
+  }
+}

--- a/iac/terraform/backend.tf
+++ b/iac/terraform/backend.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.12.2"
+
+  backend "s3" {
+    region         = "eu-west-1"
+    bucket         = "iac-dev-mentor-match-state"
+    key            = "terraform.tfstate"
+    dynamodb_table = "iac-dev-mentor-match-state-lock"
+    profile        = ""
+    role_arn       = ""
+    encrypt        = "true"
+  }
+}

--- a/iac/terraform/data.tf
+++ b/iac/terraform/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/iac/terraform/dns.tf
+++ b/iac/terraform/dns.tf
@@ -1,0 +1,25 @@
+data "aws_route53_zone" "hosting" {
+  zone_id = var.hosted_zone_id
+}
+
+
+
+
+resource "aws_apprunner_custom_domain_association" "mmweb" {
+  domain_name          = "mmweb.${data.aws_route53_zone.hosting.name}"
+  service_arn          = aws_apprunner_service.mmweb.arn
+  enable_www_subdomain = false
+}
+
+
+
+resource "aws_route53_record" "apprunner_web_certificate_validation" {
+  count = length(aws_apprunner_custom_domain_association.mmweb.certificate_validation_records)
+
+  name    = aws_apprunner_custom_domain_association.mmweb.certificate_validation_records.*.name[count.index]
+  type    = aws_apprunner_custom_domain_association.mmweb.certificate_validation_records.*.type[count.index]
+  ttl     = 300
+  zone_id = data.aws_route53_zone.hosting.id
+
+  records = [aws_apprunner_custom_domain_association.mmweb.certificate_validation_records.*.value[count.index]]
+}

--- a/iac/terraform/ecr.tf
+++ b/iac/terraform/ecr.tf
@@ -1,0 +1,26 @@
+resource "aws_ecr_repository" "mentor_match_worker" {
+  name                 = "mentor-match-worker"
+  image_tag_mutability = "MUTABLE"
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match-worker"
+  }
+}
+
+resource "aws_ecr_repository" "mentor_match_web" {
+  name                 = "mentor-match-web"
+  image_tag_mutability = "MUTABLE"
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match-web"
+  }
+}
+output "repo_url_worker" {
+  value = aws_ecr_repository.mentor_match_worker.repository_url
+}
+
+output "repo_url_web" {
+  value = aws_ecr_repository.mentor_match_web.repository_url
+}

--- a/iac/terraform/ecs.tf
+++ b/iac/terraform/ecs.tf
@@ -1,0 +1,132 @@
+data "aws_iam_policy_document" "ecs_exec_role_trust" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com", "ecs-tasks.amazonaws.com"]
+    }
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "ecs_celery_exec_role" {
+  name               = "ecs_celery_exec_role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_exec_role_trust.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_celery_exec_role" {
+  role       = aws_iam_role.ecs_celery_exec_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+resource "aws_iam_role_policy_attachment" "ecs_celery_ecr_pull" {
+  role       = aws_iam_role.ecs_celery_exec_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_ecs_cluster" "celery" {
+  name = "celery-workers"
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+  tags = {
+    Name        = "mentor-match-ecs-cluster"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_logs" {
+  name              = "/ecs/mmweb-celery/worker"
+  retention_in_days = 30
+  tags = {
+    Name        = "mentor-match-worker-ecs-logs"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+resource "aws_ecs_task_definition" "celery_worker" {
+  family                   = "mentor-match-worker"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_celery_exec_role.arn
+  task_role_arn            = aws_iam_role.ecs_celery_exec_role.arn
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+  container_definitions = jsonencode(
+    [
+      {
+        name      = "worker"
+        image     = var.worker_image_uri
+        cpu       = 256
+        memory    = 512
+        user      = "nobody"
+        privileged = false
+        essential = true
+        environment = [
+          {
+          name  = "SERVICE_URL"
+          value = "https://${aws_apprunner_service.mmweb.service_url}"
+          },
+          {
+            name = "FLASK_ENV"
+            value = "development"
+          },
+          {
+            name = "REDIS_URL"
+            value = "redis://${aws_elasticache_cluster.redis.cache_nodes.0.address}:${aws_elasticache_cluster.redis.cache_nodes.0.port}/0"
+          }
+        ]
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            "awslogs-group"         = aws_cloudwatch_log_group.ecs_logs.name
+            "awslogs-region"        = data.aws_region.current.name
+            "awslogs-stream-prefix" = "worker"
+          }
+        }
+      }
+    ]
+  )
+  tags = {
+    Name        = "mentor-match-worker"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+
+}
+
+resource "aws_ecs_service" "worker" {
+  name                = "mentor-match-worker"
+  cluster             = aws_ecs_cluster.celery.id
+  task_definition     = aws_ecs_task_definition.celery_worker.arn
+  desired_count       = 1
+  scheduling_strategy = "REPLICA"
+  launch_type         = "FARGATE"
+  platform_version    = "LATEST"
+  propagate_tags      = "TASK_DEFINITION"
+  tags = {
+    Name        = "mentor-match-worker-service"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  network_configuration {
+    subnets          = module.vpc.intra_subnets
+    security_groups  = [aws_security_group.allow_redis_from_vpc.id]
+    assign_public_ip = false
+  }
+
+
+
+}

--- a/iac/terraform/elasticache_redis.tf
+++ b/iac/terraform/elasticache_redis.tf
@@ -1,0 +1,86 @@
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "mentor-match-redis-subnets"
+  subnet_ids = module.vpc.intra_subnets
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+resource "aws_security_group" "allow_redis_from_vpc" {
+  name        = "allow_redis"
+  description = "Allow redis inbound traffic and egress anywhere"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "redis from VPC"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "allow_redis_from_vpc"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "mentor-match-redis"
+  engine               = "redis"
+  node_type            = "cache.t4g.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+  engine_version       = "6.2"
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.redis.name
+  security_group_ids   = [aws_security_group.allow_redis_from_vpc.id]
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+resource "random_password" "redis_admin_password" {
+  length  = 16
+  special = false
+  upper   = true
+  lower   = true
+  numeric = true
+}
+resource "aws_ssm_parameter" "redis_admin_password" {
+  name        = "/mentor-match/redis/password/admin"
+  description = "Redis Admin Password for Mentor Match"
+  type        = "SecureString"
+  value       = random_password.redis_admin_password.result
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+resource "aws_elasticache_user" "admin" {
+  user_id       = "redisadmin"
+  user_name     = "redisAdmin"
+  access_string = "on ~* &* +@all"
+  engine        = "REDIS"
+  passwords     = [random_password.redis_admin_password.result]
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}

--- a/iac/terraform/iam.tf
+++ b/iac/terraform/iam.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "apprunner_exec_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy"
+    ]
+    resources = ["arn:aws:logs:*:*:log-group:/aws/apprunner/*"]
+    effect    = "Allow"
+  }
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    resources = [
+      "arn:aws:logs:*:*:log-group:/aws/apprunner/*:log-stream:*"
+    ]
+    effect = "Allow"
+  }
+  statement {
+    actions = [
+      "events:PutRule",
+      "events:PutTargets",
+      "events:DeleteRule",
+      "events:RemoveTargets",
+      "events:DescribeRule",
+      "events:EnableRule",
+      "events:DisableRule"
+    ]
+    resources = ["arn:aws:events:*:*:rule/AWSAppRunnerManagedRule*"]
+    effect    = "Allow"
+  }
+}

--- a/iac/terraform/module_state.tf
+++ b/iac/terraform/module_state.tf
@@ -1,0 +1,13 @@
+module "terraform_state_backend" {
+  source = "cloudposse/tfstate-backend/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  version    = "0.38.1"
+  namespace  = "iac"
+  stage      = "dev"
+  name       = "mentor-match"
+  attributes = ["state"]
+
+  terraform_backend_config_file_path = "."
+  terraform_backend_config_file_name = "backend.tf"
+  force_destroy                      = false
+}

--- a/iac/terraform/module_vpc.tf
+++ b/iac/terraform/module_vpc.tf
@@ -1,0 +1,20 @@
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "mentor-match-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs           = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  intra_subnets = ["10.0.1.0/26", "10.0.1.64/26", "10.0.1.128/26"]
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  enable_nat_gateway = false
+  enable_vpn_gateway = false
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}

--- a/iac/terraform/outputs.tf
+++ b/iac/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "apprunner_service_url" {
+  value = aws_apprunner_service.mmweb.service_url
+}
+output "aws_apprunner_service_domain_name" {
+  value = aws_apprunner_custom_domain_association.mmweb.domain_name
+}
+
+output "certificate_records" {
+  value = aws_apprunner_custom_domain_association.mmweb.certificate_validation_records
+}
+
+output "dns_target" {
+  value = aws_apprunner_custom_domain_association.mmweb.dns_target
+
+}

--- a/iac/terraform/provider.tf
+++ b/iac/terraform/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/iac/terraform/variables.tf
+++ b/iac/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "hosted_zone_id" {
+  type = string
+}
+variable "application_image_uri" {
+  type = string
+}
+
+variable "worker_image_uri" {
+  type = string
+
+}

--- a/iac/terraform/vpce.tf
+++ b/iac/terraform/vpce.tf
@@ -1,0 +1,137 @@
+resource "aws_security_group" "allow_access_to_vpce" {
+  name        = "allow_vpce"
+  description = "Allow vpce https inbound traffic and egress anywhere"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "https from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "allow_vpce_from_vpc"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
+  private_dns_enabled = true
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  security_group_ids  = [aws_security_group.allow_access_to_vpce.id]
+  tags = {
+    Name        = "ecr_api"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Interface"
+  auto_accept       = true
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
+  private_dns_enabled = true
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  security_group_ids  = [aws_security_group.allow_access_to_vpce.id]
+  tags = {
+    Name        = "ecr_dkr"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Interface"
+  auto_accept       = true
+}
+
+resource "aws_vpc_endpoint" "ecs_agent" {
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecs-agent"
+  private_dns_enabled = true
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  security_group_ids  = [aws_security_group.allow_access_to_vpce.id]
+  tags = {
+    Name        = "ecs_agent"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Interface"
+  auto_accept       = true
+}
+resource "aws_vpc_endpoint" "ecs_telemetry" {
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecs-telemetry"
+  private_dns_enabled = true
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  security_group_ids  = [aws_security_group.allow_access_to_vpce.id]
+  tags = {
+    Name        = "ecs_telemetry"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Interface"
+  auto_accept       = true
+}
+resource "aws_vpc_endpoint" "ecs" {
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecs"
+  private_dns_enabled = true
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  security_group_ids  = [aws_security_group.allow_access_to_vpce.id]
+  tags = {
+    Name        = "ecs"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Interface"
+  auto_accept       = true
+}
+
+resource "aws_vpc_endpoint" "cloudwatch" {
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.logs"
+  private_dns_enabled = true
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  security_group_ids  = [aws_security_group.allow_access_to_vpce.id]
+  tags = {
+    Name        = "cloudwatch"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Interface"
+  auto_accept       = true
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_id          = module.vpc.vpc_id
+  route_table_ids = module.vpc.intra_route_table_ids
+  tags = {
+    Name        = "s3"
+    Terraform   = "true"
+    Environment = "dev"
+    Project     = "mentor-match"
+  }
+  vpc_endpoint_type = "Gateway"
+  auto_accept       = true
+
+}


### PR DESCRIPTION
Here's some Terraform I wrote last week to deploy MentorMatch to AWS within its own VPC. 
There are a few manual operations required, such as bringing in a domain as a Hosted Zone with Route53, and pushing the application docker images to ECR, which wouldn't have been optimal to terraform in this case. 

Hosting the service uses AWS App Runner and AWS Fargate, with a single node backend Redis in AWS Elasticache. 
